### PR TITLE
fix: Read meteroid api uri from env var

### DIFF
--- a/modules/web/web-app/App.tsx
+++ b/modules/web/web-app/App.tsx
@@ -20,7 +20,7 @@ const queryClient = new QueryClient({
 
 export const App: React.FC = () => {
   const transport = createGrpcWebTransport({
-    baseUrl: 'http://127.0.0.1:50061',
+    baseUrl: env.meteroidApiUri,
     interceptors: [errorInterceptor, loggingInterceptor, authInterceptor],
   })
   return (

--- a/modules/web/web-app/lib/env.ts
+++ b/modules/web/web-app/lib/env.ts
@@ -4,9 +4,11 @@ import { z } from 'zod'
 const _env = parseEnv(import.meta.env, {
   VITE_DEBUG_MODE: z.boolean().default(false),
   VITE_API_URL: z.string().default('http://127.0.0.1:8000'),
+  METEROID_URI: z.string().default('http://127.0.0.1:50061'),
 })
 
 export const env = {
   isDebug: _env.VITE_DEBUG_MODE,
   apiUrl: _env.VITE_API_URL,
+  meteroidApiUri: _env.METEROID_URI,
 }


### PR DESCRIPTION
## Description
Use env var for meteroid api uri

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
