### PR TITLE
chore: reduce nextest time

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install dependencies
         run: |
-          sudo apt-get install -y cmake clang unzip postgresql libsasl2-dev
+          sudo apt-get install -y cmake clang unzip libsasl2-dev
           wget https://github.com/protocolbuffers/protobuf/releases/download/v21.8/protoc-21.8-linux-x86_64.zip
           unzip protoc*.zip
           sudo mv bin/protoc /usr/local/bin
@@ -45,12 +45,14 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.3
-      - name: Compile
-        run: cargo check
       - name: Install nextest
-        run: cargo install cargo-nextest
+        uses: taiki-e/cache-cargo-install-action@v1
+        with:
+          tool: cargo-nextest
       - name: Test
         run: cargo nextest run
+      - name: Compile
+        run: cargo check
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
## Description
installing nextest takes 4min out of our 10m ci time on every pr. Trying to use a dedicated cache and change order (cf [quickwit](https://github.com/quickwit-oss/quickwit/blob/main/.github/workflows/ci.yml))

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
