### PR TITLE
feat: Introduce eventbus and webhook handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ lazy_static = "1"
 log = "0.4.20"
 miette = { version = "7.0.0", default-features = false }
 moka = { version = "0.12.3", features = ["log", "logging", "sync"]}
+mockito = "1.2.0"
 nanoid = "0.4.0"
 once_cell = "1.18.0"
 pin-project = "1.1.3"

--- a/modules/meteroid/Cargo.toml
+++ b/modules/meteroid/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 error-stack.workspace = true
 thiserror.workspace = true
 blake3.workspace = true
+cached = { workspace = true, features = ["async", "tokio"] }
 chrono = { workspace = true, features = ["clock"] }
 common-config = { workspace = true }
 common-logging = { workspace = true }
@@ -24,6 +25,7 @@ log.workspace = true
 nanoid.workspace = true
 prost-types.workspace = true
 prost.workspace = true
+reqwest = { workspace = true, features = ["default"] }
 serde_json.workspace = true
 serde.workspace = true
 time.workspace = true
@@ -54,7 +56,6 @@ chacha20poly1305.workspace = true
 anyhow.workspace = true
 axum = { workspace = true, features = ["default", "macros", "http2"] }
 hyper = { workspace = true, features = ["http1", "http2", "server"] }
-reqwest = { workspace = true, optional = true }
 
 rust_decimal = { workspace = true, features = ["serde_json"] }
 rust_decimal_macros = { workspace = true }
@@ -90,6 +91,7 @@ clickhouse-rs = { workspace = true }
 rdkafka = { workspace = true }
 metering = { workspace = true }
 kafka = { workspace = true }
+mockito = { workspace = true }
 
 [[bin]]
 name = "meteroid-api"

--- a/modules/meteroid/crates/meteroid-repository/src/cornucopia.rs
+++ b/modules/meteroid/crates/meteroid-repository/src/cornucopia.rs
@@ -1159,7 +1159,7 @@ pub mod queries {
             }
         }
         pub fn list_api_tokens() -> ListApiTokensStmt {
-            ListApiTokensStmt(cornucopia_async :: private :: Stmt :: new("SELECT id, tenant_id, name, hint, created_at, created_by FROM api_token WHERE tenant_id = $1"))
+            ListApiTokensStmt(cornucopia_async::private::Stmt::new("SELECT id, tenant_id, name, hint, created_at, created_by FROM api_token WHERE tenant_id = $1"))
         }
         pub struct ListApiTokensStmt(cornucopia_async::private::Stmt);
         impl ListApiTokensStmt {
@@ -2413,7 +2413,7 @@ WHERE bm.id = ANY ($1)
             }
         }
         pub fn create_customer() -> CreateCustomerStmt {
-            CreateCustomerStmt(cornucopia_async :: private :: Stmt :: new("INSERT INTO customer (id, name, alias, email, tenant_id, created_by, billing_config)
+            CreateCustomerStmt(cornucopia_async::private::Stmt::new("INSERT INTO customer (id, name, alias, email, tenant_id, created_by, billing_config)
 VALUES ($1,
         $2,
         $3,
@@ -3494,7 +3494,7 @@ WHERE id = $10",
             }
         }
         pub fn create_invoice() -> CreateInvoiceStmt {
-            CreateInvoiceStmt(cornucopia_async :: private :: Stmt :: new("INSERT INTO invoice (id, status, invoicing_provider, invoice_date, tenant_id, customer_id, subscription_id,
+            CreateInvoiceStmt(cornucopia_async::private::Stmt::new("INSERT INTO invoice (id, status, invoicing_provider, invoice_date, tenant_id, customer_id, subscription_id,
                      currency, days_until_due, line_items, amount_cents)
 VALUES ($1, $2, $3, $4, $5, $6, $7,
         $8, $9, $10, $11)
@@ -3732,7 +3732,7 @@ WHERE id = $2
             }
         }
         pub fn patch_invoice() -> PatchInvoiceStmt {
-            PatchInvoiceStmt(cornucopia_async :: private :: Stmt :: new("UPDATE invoice
+            PatchInvoiceStmt(cornucopia_async::private::Stmt::new("UPDATE invoice
 SET status             = COALESCE($1, status),
     invoicing_provider = COALESCE($2, invoicing_provider),
     invoice_date       = COALESCE($3, invoice_date),
@@ -3916,7 +3916,7 @@ WHERE invoice.status NOT IN ('VOID', 'FINALIZED')
             }
         }
         pub fn get_outdated_invoices() -> GetOutdatedInvoicesStmt {
-            GetOutdatedInvoicesStmt(cornucopia_async :: private :: Stmt :: new("SELECT invoice.id,
+            GetOutdatedInvoicesStmt(cornucopia_async::private::Stmt::new("SELECT invoice.id,
        invoice.status,
        invoice.invoicing_provider,
        invoice.invoice_date,
@@ -4835,7 +4835,7 @@ WHERE invoice.id = $1
         }
         impl<'a> From<GetOrganizationByInviteHashBorrowed<'a>> for GetOrganizationByInviteHash {
             fn from(
-                GetOrganizationByInviteHashBorrowed { id,name,} : GetOrganizationByInviteHashBorrowed < 'a >,
+                GetOrganizationByInviteHashBorrowed { id,name,}: GetOrganizationByInviteHashBorrowed<'a>,
             ) -> Self {
                 Self {
                     id,
@@ -7523,7 +7523,7 @@ WHERE
             }
         }
         pub fn upsert_price_component() -> UpsertPriceComponentStmt {
-            UpsertPriceComponentStmt(cornucopia_async :: private :: Stmt :: new("INSERT INTO price_component (id, name, fee, plan_version_id, product_item_id, billable_metric_id)
+            UpsertPriceComponentStmt(cornucopia_async::private::Stmt::new("INSERT INTO price_component (id, name, fee, plan_version_id, product_item_id, billable_metric_id)
 SELECT $1,
        $2,
        $3,
@@ -8655,7 +8655,7 @@ WHERE
             }
         }
         pub fn get_config_by_provider_and_endpoint() -> GetConfigByProviderAndEndpointStmt {
-            GetConfigByProviderAndEndpointStmt(cornucopia_async :: private :: Stmt :: new("SELECT id, tenant_id, invoicing_provider, enabled, webhook_security, api_security FROM provider_config WHERE tenant_id = $1 AND invoicing_provider = $2 AND enabled = TRUE"))
+            GetConfigByProviderAndEndpointStmt(cornucopia_async::private::Stmt::new("SELECT id, tenant_id, invoicing_provider, enabled, webhook_security, api_security FROM provider_config WHERE tenant_id = $1 AND invoicing_provider = $2 AND enabled = TRUE"))
         }
         pub struct GetConfigByProviderAndEndpointStmt(cornucopia_async::private::Stmt);
         impl GetConfigByProviderAndEndpointStmt {
@@ -8698,7 +8698,7 @@ WHERE
             }
         }
         pub fn create_provider_config() -> CreateProviderConfigStmt {
-            CreateProviderConfigStmt(cornucopia_async :: private :: Stmt :: new("INSERT INTO provider_config (id, tenant_id, invoicing_provider, enabled, webhook_security, api_security)
+            CreateProviderConfigStmt(cornucopia_async::private::Stmt::new("INSERT INTO provider_config (id, tenant_id, invoicing_provider, enabled, webhook_security, api_security)
 VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (tenant_id, invoicing_provider)
   where enabled = TRUE
@@ -9236,7 +9236,7 @@ WHERE s.id = $1
             }
         }
         pub fn create_slot_transaction() -> CreateSlotTransactionStmt {
-            CreateSlotTransactionStmt(cornucopia_async :: private :: Stmt :: new("insert into slot_transaction(id, price_component_id, subscription_id, delta, prev_active_slots, effective_at, transaction_at)
+            CreateSlotTransactionStmt(cornucopia_async::private::Stmt::new("insert into slot_transaction(id, price_component_id, subscription_id, delta, prev_active_slots, effective_at, transaction_at)
 values ($1,
         $2,
         $3,
@@ -9302,7 +9302,7 @@ returning id"))
             }
         }
         pub fn get_active_slots() -> GetActiveSlotsStmt {
-            GetActiveSlotsStmt(cornucopia_async :: private :: Stmt :: new("WITH RankedSlotTransactions AS (
+            GetActiveSlotsStmt(cornucopia_async::private::Stmt::new("WITH RankedSlotTransactions AS (
   SELECT
     st.*,
     ROW_NUMBER() OVER (PARTITION BY st.subscription_id, st.price_component_id ORDER BY st.transaction_at DESC) AS row_num
@@ -11740,7 +11740,7 @@ FROM
             }
         }
         pub fn get_webhook_in_event_by_id() -> GetWebhookInEventByIdStmt {
-            GetWebhookInEventByIdStmt(cornucopia_async :: private :: Stmt :: new("SELECT id, received_at, action, key, processed, attempts, error, provider_config_id FROM webhook_in_event WHERE id = $1"))
+            GetWebhookInEventByIdStmt(cornucopia_async::private::Stmt::new("SELECT id, received_at, action, key, processed, attempts, error, provider_config_id FROM webhook_in_event WHERE id = $1"))
         }
         pub struct GetWebhookInEventByIdStmt(cornucopia_async::private::Stmt);
         impl GetWebhookInEventByIdStmt {
@@ -11825,7 +11825,7 @@ RETURNING id, received_at, action, key, processed, attempts, error, provider_con
             }
         }
         pub fn find_webhook_in_events_by_tenant_id() -> FindWebhookInEventsByTenantIdStmt {
-            FindWebhookInEventsByTenantIdStmt(cornucopia_async :: private :: Stmt :: new("SELECT webhook_in_event.id, webhook_in_event.received_at, webhook_in_event.action, webhook_in_event.key, webhook_in_event.processed, webhook_in_event.attempts, webhook_in_event.error, provider_config.invoicing_provider
+            FindWebhookInEventsByTenantIdStmt(cornucopia_async::private::Stmt::new("SELECT webhook_in_event.id, webhook_in_event.received_at, webhook_in_event.action, webhook_in_event.key, webhook_in_event.processed, webhook_in_event.attempts, webhook_in_event.error, provider_config.invoicing_provider
 FROM webhook_in_event
 JOIN provider_config ON provider_config.id = webhook_in_event.provider_config_id
 WHERE provider_config.tenant_id = $1"))
@@ -11981,7 +11981,7 @@ WHERE provider_config.tenant_id = $1"))
             }
         }
         pub fn create_endpoint() -> CreateEndpointStmt {
-            CreateEndpointStmt(cornucopia_async :: private :: Stmt :: new("insert into webhook_out_endpoint (id, tenant_id, url, description, secret, events_to_listen, enabled)
+            CreateEndpointStmt(cornucopia_async::private::Stmt::new("insert into webhook_out_endpoint (id, tenant_id, url, description, secret, events_to_listen, enabled)
 values ($1, $2, $3, $4, $5, $6, $7)
 returning id, tenant_id, url, description, secret, created_at, events_to_listen, enabled"))
         }
@@ -12068,7 +12068,7 @@ returning id, tenant_id, url, description, secret, created_at, events_to_listen,
             }
         }
         pub fn list_endpoints() -> ListEndpointsStmt {
-            ListEndpointsStmt(cornucopia_async :: private :: Stmt :: new("select id, tenant_id, url, description, secret, created_at, events_to_listen, enabled
+            ListEndpointsStmt(cornucopia_async::private::Stmt::new("select id, tenant_id, url, description, secret, created_at, events_to_listen, enabled
 from webhook_out_endpoint
 where tenant_id = $1"))
         }

--- a/modules/meteroid/src/api/services/customers/mod.rs
+++ b/modules/meteroid/src/api/services/customers/mod.rs
@@ -1,11 +1,35 @@
-use crate::db::DbService;
+use crate::db::{get_connection, get_transaction};
+use crate::eventbus::{Event, EventBus};
+use deadpool_postgres::{Object, Transaction};
 use meteroid_grpc::meteroid::api::customers::v1::customers_service_server::CustomersServiceServer;
 use meteroid_repository::Pool;
+use std::sync::Arc;
+use tonic::Status;
 
 pub mod mapping;
 mod service;
 
-pub fn service(pool: Pool) -> CustomersServiceServer<DbService> {
-    let inner = DbService::new(pool);
+pub struct CustomerServiceComponents {
+    pub pool: Pool,
+    pub eventbus: Arc<dyn EventBus<Event>>,
+}
+
+impl CustomerServiceComponents {
+    pub async fn get_connection(&self) -> Result<Object, Status> {
+        get_connection(&self.pool).await
+    }
+    pub async fn get_transaction<'a>(
+        &'a self,
+        client: &'a mut Object,
+    ) -> Result<Transaction<'a>, Status> {
+        get_transaction(client).await
+    }
+}
+
+pub fn service(
+    pool: Pool,
+    eventbus: Arc<dyn EventBus<Event>>,
+) -> CustomersServiceServer<CustomerServiceComponents> {
+    let inner = CustomerServiceComponents { pool, eventbus };
     CustomersServiceServer::new(inner)
 }

--- a/modules/meteroid/src/api/services/subscriptions/mod.rs
+++ b/modules/meteroid/src/api/services/subscriptions/mod.rs
@@ -1,5 +1,6 @@
 use crate::compute::InvoiceEngine;
 use crate::db::{get_connection, get_transaction};
+use crate::eventbus::{Event, EventBus};
 use deadpool_postgres::{Object, Transaction};
 use meteroid_grpc::meteroid::api::subscriptions::v1::subscriptions_service_server::SubscriptionsServiceServer;
 use meteroid_repository::Pool;
@@ -15,6 +16,7 @@ mod service;
 pub struct SubscriptionServiceComponents {
     pub pool: Pool,
     pub compute_service: Arc<InvoiceEngine>,
+    pub eventbus: Arc<dyn EventBus<Event>>,
 }
 
 impl SubscriptionServiceComponents {
@@ -32,10 +34,12 @@ impl SubscriptionServiceComponents {
 pub fn service(
     pool: Pool,
     subscription_billing: Arc<InvoiceEngine>,
+    eventbus: Arc<dyn EventBus<Event>>,
 ) -> SubscriptionsServiceServer<SubscriptionServiceComponents> {
     let inner = SubscriptionServiceComponents {
         pool,
         compute_service: subscription_billing,
+        eventbus,
     };
     SubscriptionsServiceServer::new(inner)
 }

--- a/modules/meteroid/src/api/services/subscriptions/service.rs
+++ b/modules/meteroid/src/api/services/subscriptions/service.rs
@@ -6,6 +6,7 @@ use crate::compute::clients::subscription::SubscriptionClient;
 use crate::compute::fees::shared::CadenceExtractor;
 use crate::compute::fees::ComputeInvoiceLine;
 use crate::compute::period;
+use crate::eventbus::Event;
 use crate::mapping::common::{chrono_to_date, chrono_to_datetime, date_to_chrono};
 use crate::models::InvoiceLine;
 use crate::parse_uuid;
@@ -293,6 +294,14 @@ impl SubscriptionsService for SubscriptionServiceComponents {
                 .set_source(Arc::new(e))
                 .clone()
         })?;
+
+        let _ = self
+            .eventbus
+            .publish(Event::subscription_created(
+                subscription.subscription_id,
+                subscription.tenant_id,
+            ))
+            .await;
 
         let rs = mapping::subscriptions::db_to_proto(subscription)?;
 

--- a/modules/meteroid/src/eventbus.rs
+++ b/modules/meteroid/src/eventbus.rs
@@ -1,0 +1,125 @@
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(thiserror::Error, Debug)]
+pub enum EventBusError {
+    #[error("Failed to publish event")]
+    PublishFailed,
+    //#[error("Failed to handle event")]
+    //EventHandlerFailed(Box<dyn std::error::Error>),
+}
+
+/**
+ * EventBus is a simple event bus implementation.
+ * It allows to have one publisher many subscribers.
+ * NOTE:
+ *   It doesn't use persistent storage, the publisher is decoupled from the subscribers
+ *   so if the process dies, all in-flight events are lost.
+ */
+pub struct EventBus<E> {
+    pub sender: tokio::sync::broadcast::Sender<E>,
+}
+
+#[async_trait::async_trait]
+pub trait EventHandler<E>: Send + Sync {
+    async fn handle(&self, event: E) -> Result<(), EventBusError>;
+}
+
+impl<E: Debug + Clone + Send + 'static> EventBus<E> {
+    pub fn new() -> Self {
+        let (snd, _) = tokio::sync::broadcast::channel(1000);
+
+        EventBus { sender: snd }
+    }
+
+    pub fn subscribe(&self, handler: Arc<dyn EventHandler<E>>) {
+        let mut rx = self.sender.subscribe();
+        tokio::spawn(async move {
+            loop {
+                let handler = handler.clone();
+                match rx.recv().await {
+                    Ok(event) => {
+                        tokio::spawn(async move {
+                            match handler.handle(event).await {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    log::error!("Error handling event. Ignoring it. {:?}", e)
+                                }
+                            };
+                        });
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Error receiving event from broadcast channel. Ignoring it. {:?}",
+                            e
+                        );
+                    }
+                };
+            }
+        });
+    }
+
+    pub fn publish(&self, event: E) -> Result<usize, EventBusError> {
+        self.sender
+            .send(event)
+            .map_err(|_| EventBusError::PublishFailed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::eventbus;
+    use crate::eventbus::{EventBus, EventHandler};
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct CapturingEventHandler {
+        items: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl CapturingEventHandler {
+        pub fn new() -> Self {
+            CapturingEventHandler {
+                items: Arc::new(Mutex::new(vec![])),
+            }
+        }
+
+        pub fn items(&self) -> HashSet<u8> {
+            self.items.lock().unwrap().clone().into_iter().collect()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl EventHandler<u8> for CapturingEventHandler {
+        async fn handle(&self, event: u8) -> Result<(), eventbus::EventBusError> {
+            let mut guard = self.items.lock().unwrap();
+            guard.push(event);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn eventbus_test() {
+        let bus = EventBus::new();
+
+        let handler1 = CapturingEventHandler::new();
+        let handler2 = CapturingEventHandler::new();
+
+        bus.subscribe(Arc::new(handler1.clone()));
+        bus.subscribe(Arc::new(handler2.clone()));
+
+        bus.publish(1).unwrap();
+        bus.publish(2).unwrap();
+        bus.publish(3).unwrap();
+        bus.publish(4).unwrap();
+        bus.publish(5).unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+
+        let expected: HashSet<u8> = [1, 2, 3, 4, 5].iter().cloned().collect();
+
+        assert_eq!(handler1.clone().items(), expected);
+        assert_eq!(handler2.clone().items(), expected);
+    }
+}

--- a/modules/meteroid/src/eventbus.rs
+++ b/modules/meteroid/src/eventbus.rs
@@ -5,13 +5,13 @@ use std::sync::Arc;
 pub enum EventBusError {
     #[error("Failed to publish event")]
     PublishFailed,
-    //#[error("Failed to handle event")]
-    //EventHandlerFailed(Box<dyn std::error::Error>),
+    #[error("Failed to handle event")]
+    EventHandlerFailed(Box<dyn std::error::Error>),
 }
 
 /**
  * EventBus is a simple event bus implementation.
- * It allows to have one publisher many subscribers.
+ * It allows to have one publisher and many subscribers.
  * NOTE:
  *   It doesn't use persistent storage, the publisher is decoupled from the subscribers
  *   so if the process dies, all in-flight events are lost.

--- a/modules/meteroid/src/eventbus/memory.rs
+++ b/modules/meteroid/src/eventbus/memory.rs
@@ -1,38 +1,21 @@
+use crate::eventbus::{EventBus, EventBusError, EventHandler};
 use std::fmt::Debug;
 use std::sync::Arc;
 
-#[derive(thiserror::Error, Debug)]
-pub enum EventBusError {
-    #[error("Failed to publish event")]
-    PublishFailed,
-    #[error("Failed to handle event")]
-    EventHandlerFailed(Box<dyn std::error::Error>),
-}
-
 /**
- * EventBus is a simple event bus implementation.
+ * Simple in-memory event bus implementation.
  * It allows to have one publisher and many subscribers.
  * NOTE:
- *   It doesn't use persistent storage, the publisher is decoupled from the subscribers
- *   so if the process dies, all in-flight events are lost.
+ *   As it doesn't use persistent storage and the publisher is decoupled from the subscribers,
+ *   if the process dies then all in-flight events are lost.
  */
-pub struct EventBus<E> {
+pub struct InMemory<E> {
     pub sender: tokio::sync::broadcast::Sender<E>,
 }
 
 #[async_trait::async_trait]
-pub trait EventHandler<E>: Send + Sync {
-    async fn handle(&self, event: E) -> Result<(), EventBusError>;
-}
-
-impl<E: Debug + Clone + Send + 'static> EventBus<E> {
-    pub fn new() -> Self {
-        let (snd, _) = tokio::sync::broadcast::channel(1000);
-
-        EventBus { sender: snd }
-    }
-
-    pub fn subscribe(&self, handler: Arc<dyn EventHandler<E>>) {
+impl<E: Debug + Clone + Send + 'static> EventBus<E> for InMemory<E> {
+    async fn subscribe(&self, handler: Arc<dyn EventHandler<E>>) {
         let mut rx = self.sender.subscribe();
         tokio::spawn(async move {
             loop {
@@ -59,16 +42,26 @@ impl<E: Debug + Clone + Send + 'static> EventBus<E> {
         });
     }
 
-    pub fn publish(&self, event: E) -> Result<usize, EventBusError> {
+    async fn publish(&self, event: E) -> Result<(), EventBusError> {
         self.sender
             .send(event)
+            .map(|_| ())
             .map_err(|_| EventBusError::PublishFailed)
+    }
+}
+
+impl<E: Debug + Clone + Send + 'static> InMemory<E> {
+    pub fn new() -> Self {
+        let (snd, _) = tokio::sync::broadcast::channel(1000);
+
+        InMemory { sender: snd }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::eventbus;
+    use crate::eventbus::memory::InMemory;
     use crate::eventbus::{EventBus, EventHandler};
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
@@ -101,19 +94,19 @@ mod tests {
 
     #[tokio::test]
     async fn eventbus_test() {
-        let bus = EventBus::new();
+        let bus = InMemory::new();
 
         let handler1 = CapturingEventHandler::new();
         let handler2 = CapturingEventHandler::new();
 
-        bus.subscribe(Arc::new(handler1.clone()));
-        bus.subscribe(Arc::new(handler2.clone()));
+        bus.subscribe(Arc::new(handler1.clone())).await;
+        bus.subscribe(Arc::new(handler2.clone())).await;
 
-        bus.publish(1).unwrap();
-        bus.publish(2).unwrap();
-        bus.publish(3).unwrap();
-        bus.publish(4).unwrap();
-        bus.publish(5).unwrap();
+        bus.publish(1).await.unwrap();
+        bus.publish(2).await.unwrap();
+        bus.publish(3).await.unwrap();
+        bus.publish(4).await.unwrap();
+        bus.publish(5).await.unwrap();
 
         tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 

--- a/modules/meteroid/src/eventbus/mod.rs
+++ b/modules/meteroid/src/eventbus/mod.rs
@@ -1,13 +1,14 @@
 use std::sync::Arc;
+use uuid::Uuid;
 
 pub mod memory;
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, Clone)]
 pub enum EventBusError {
     #[error("Failed to publish event")]
     PublishFailed,
-    #[error("Failed to handle event")]
-    EventHandlerFailed(Box<dyn std::error::Error>),
+    #[error("Failed to handle event {0}: {1}")]
+    EventHandlerFailed(Uuid, String),
 }
 
 #[async_trait::async_trait]
@@ -19,4 +20,32 @@ pub trait EventHandler<E>: Send + Sync {
 pub trait EventBus<E>: Send + Sync {
     async fn subscribe(&self, handler: Arc<dyn EventHandler<E>>);
     async fn publish(&self, event: E) -> Result<(), EventBusError>;
+}
+
+#[derive(Debug)]
+struct Event {
+    pub event_id: Uuid,
+    pub event_timestamp: chrono::DateTime<chrono::Utc>,
+    pub event_data: EventData,
+}
+
+#[derive(Debug)]
+enum EventData {
+    OrganizationCreated(EventDataDetails),
+    TenantCreated(TenantEventDataDetails),
+    CustomerCreated(TenantEventDataDetails),
+    SubscriptionCreated(TenantEventDataDetails),
+    InvoiceCreated(TenantEventDataDetails),
+    InvoiceFinalized(TenantEventDataDetails),
+}
+
+#[derive(Debug)]
+pub struct EventDataDetails {
+    pub entity_id: Uuid,
+}
+
+#[derive(Debug)]
+pub struct TenantEventDataDetails {
+    pub tenant_id: Uuid,
+    pub entity_id: Uuid,
 }

--- a/modules/meteroid/src/eventbus/mod.rs
+++ b/modules/meteroid/src/eventbus/mod.rs
@@ -1,0 +1,22 @@
+use std::sync::Arc;
+
+pub mod memory;
+
+#[derive(thiserror::Error, Debug)]
+pub enum EventBusError {
+    #[error("Failed to publish event")]
+    PublishFailed,
+    #[error("Failed to handle event")]
+    EventHandlerFailed(Box<dyn std::error::Error>),
+}
+
+#[async_trait::async_trait]
+pub trait EventHandler<E>: Send + Sync {
+    async fn handle(&self, event: E) -> Result<(), EventBusError>;
+}
+
+#[async_trait::async_trait]
+pub trait EventBus<E>: Send + Sync {
+    async fn subscribe(&self, handler: Arc<dyn EventHandler<E>>);
+    async fn publish(&self, event: E) -> Result<(), EventBusError>;
+}

--- a/modules/meteroid/src/eventbus/webhook_handler.rs
+++ b/modules/meteroid/src/eventbus/webhook_handler.rs
@@ -1,0 +1,439 @@
+use crate::eventbus::{Event, EventBusError, EventData, EventHandler, TenantEventDataDetails};
+use crate::mapping::common::date_to_chrono;
+use crate::webhook;
+use crate::webhook::Webhook;
+use cached::proc_macro::cached;
+use common_repository::Pool;
+use meteroid_repository::WebhookOutEventTypeEnum;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Serialize;
+use uuid::Uuid;
+
+pub struct WebhookHandler {
+    pub pool: Pool,
+    pub crypt_key: SecretString,
+    pub client: reqwest::Client,
+    pub cache_enabled: bool,
+}
+
+impl WebhookHandler {
+    pub fn new(pool: Pool, crypt_key: SecretString, cache_enabled: bool) -> Self {
+        WebhookHandler {
+            pool,
+            crypt_key,
+            client: reqwest::Client::new(),
+            cache_enabled,
+        }
+    }
+
+    async fn get_db_connection(&self) -> Result<deadpool_postgres::Object, EventBusError> {
+        self.pool
+            .get()
+            .await
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn send_webhook_event(
+        &self,
+        event: &Event,
+        webhook_event: &WebhookEvent,
+        webhook_event_payload: &Vec<u8>,
+        endpoint: &Endpoint,
+    ) -> Result<(), EventBusError> {
+        log::debug!("Sending event {:?} to endpoint {}", event, endpoint.url);
+
+        let webhook = Webhook::new(endpoint.secret.as_str()).map_err(|e| {
+            EventBusError::EventHandlerFailed(format!("Invalid webhook signature: {}", e))
+        })?;
+
+        let signature = webhook
+            .sign(
+                event.event_id.to_string().as_str(),
+                event.event_timestamp.timestamp(),
+                webhook_event_payload.as_slice(),
+            )
+            .map_err(|e| {
+                EventBusError::EventHandlerFailed(format!("Failed to sign event: {}", e))
+            })?;
+
+        let response = self
+            .client
+            .post(&endpoint.url)
+            .header(webhook::HEADER_WEBHOOK_ID, event.event_id.to_string())
+            .header(
+                webhook::HEADER_WEBHOOK_TIMESTAMP,
+                event.event_timestamp.timestamp(),
+            )
+            .header(webhook::HEADER_WEBHOOK_SIGNATURE, signature)
+            .json(&webhook_event)
+            .send()
+            .await
+            .map_err(|e| {
+                EventBusError::EventHandlerFailed(format!(
+                    "Failed to send event to endpoint: {}",
+                    e
+                ))
+            })?;
+
+        if !response.status().is_success() {
+            return Err(EventBusError::EventHandlerFailed(format!(
+                "Failed to send event to endpoint: {}",
+                response.status()
+            )));
+        }
+
+        Ok(())
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn get_active_endpoints(&self, event: &Event) -> Result<Vec<Endpoint>, EventBusError> {
+        let event_type = get_event_type(event);
+        let details = get_tenant_event_details(event);
+
+        let endpoints = if let (Some(event_type), Some(details)) = (event_type, details) {
+            let endpoints = if self.cache_enabled {
+                get_active_endpoints_by_tenant_cached(
+                    self.pool.clone(),
+                    &details.tenant_id,
+                    &self.crypt_key,
+                )
+                .await?
+            } else {
+                get_active_endpoints_by_tenant(
+                    self.pool.clone(),
+                    &details.tenant_id,
+                    &self.crypt_key,
+                )
+                .await?
+            };
+
+            endpoints
+                .into_iter()
+                .filter(|e| e.event_types.contains(&event_type))
+                .collect()
+        } else {
+            vec![]
+        };
+
+        Ok(endpoints)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn customer_created_webhook(
+        &self,
+        event: &Event,
+        event_data_details: &TenantEventDataDetails,
+    ) -> Result<WebhookEvent, EventBusError> {
+        let conn = self.get_db_connection().await?;
+
+        let customer = meteroid_repository::customers::get_customer_by_id()
+            .bind(&conn, &event_data_details.entity_id)
+            .one()
+            .await
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let event = WebhookEvent {
+            event_type: "customer.created".to_string(),
+            timestamp: event.event_timestamp,
+            data: to_json(CustomerData {
+                name: customer.name,
+                email: customer.email,
+                invoicing_email: customer.invoicing_email,
+                phone: customer.phone,
+                balance_value_cents: customer.balance_value_cents,
+            })?,
+        };
+
+        Ok(event)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn subscription_created_webhook(
+        &self,
+        event: &Event,
+        event_data_details: &TenantEventDataDetails,
+    ) -> Result<WebhookEvent, EventBusError> {
+        let conn = self.get_db_connection().await?;
+
+        let subscription = meteroid_repository::subscriptions::subscription_by_id()
+            .bind(
+                &conn,
+                &event_data_details.entity_id,
+                &event_data_details.tenant_id,
+            )
+            .one()
+            .await
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let start_date = date_to_chrono(subscription.billing_start_date)
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let end_date = subscription
+            .billing_end_date
+            .map(|d| {
+                date_to_chrono(d).map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))
+            })
+            .transpose()?;
+
+        let event = WebhookEvent {
+            event_type: "subscription.created".to_string(),
+            timestamp: event.event_timestamp,
+            data: to_json(SubscriptionData {
+                customer_name: subscription.customer_name,
+                billing_day: subscription.billing_day,
+                billing_start_date: start_date,
+                billing_end_date: end_date,
+                currency: subscription.currency,
+                net_terms: subscription.net_terms,
+            })?,
+        };
+
+        Ok(event)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn invoice_draft_webhook(
+        &self,
+        event: &Event,
+        event_data_details: &TenantEventDataDetails,
+    ) -> Result<WebhookEvent, EventBusError> {
+        let conn = self.get_db_connection().await?;
+
+        let invoice = meteroid_repository::invoices::get_tenant_invoice_by_id()
+            .bind(
+                &conn,
+                &event_data_details.entity_id,
+                &event_data_details.tenant_id,
+            )
+            .one()
+            .await
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let invoice_date = date_to_chrono(invoice.invoice_date)
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let event = WebhookEvent {
+            event_type: "invoice.draft".to_string(),
+            timestamp: event.event_timestamp,
+            data: to_json(InvoiceData {
+                customer_name: invoice.customer_name,
+                currency: invoice.currency,
+                status: "draft".to_string(),
+                invoice_date,
+                amount_cents: invoice.amount_cents,
+                plan_name: invoice.plan_name,
+            })?,
+        };
+
+        Ok(event)
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn invoice_finalized_webhook(
+        &self,
+        event: &Event,
+        event_data_details: &TenantEventDataDetails,
+    ) -> Result<WebhookEvent, EventBusError> {
+        let conn = self.get_db_connection().await?;
+
+        let invoice = meteroid_repository::invoices::get_tenant_invoice_by_id()
+            .bind(
+                &conn,
+                &event_data_details.entity_id,
+                &event_data_details.tenant_id,
+            )
+            .one()
+            .await
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let invoice_date = date_to_chrono(invoice.invoice_date)
+            .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+        let event = WebhookEvent {
+            event_type: "invoice.finalized".to_string(),
+            timestamp: event.event_timestamp,
+            data: to_json(InvoiceData {
+                customer_name: invoice.customer_name,
+                currency: invoice.currency,
+                status: "finalized".to_string(),
+                invoice_date,
+                amount_cents: invoice.amount_cents,
+                plan_name: invoice.plan_name,
+            })?,
+        };
+
+        Ok(event)
+    }
+}
+
+#[async_trait::async_trait]
+impl EventHandler<Event> for WebhookHandler {
+    #[tracing::instrument(skip_all)]
+    async fn handle(&self, event: Event) -> Result<(), EventBusError> {
+        log::debug!("Handling event: {:?}", event);
+
+        let endpoints = self.get_active_endpoints(&event).await?;
+
+        if endpoints.is_empty() {
+            log::debug!("No active endpoints found for event: {:?}", event);
+            return Ok(());
+        }
+
+        let webhook_event = match &event.event_data {
+            EventData::CustomerCreated(details) => {
+                self.customer_created_webhook(&event, details).await?
+            }
+            EventData::SubscriptionCreated(details) => {
+                self.subscription_created_webhook(&event, details).await?
+            }
+            EventData::InvoiceCreated(details) => {
+                self.invoice_draft_webhook(&event, details).await?
+            }
+            EventData::InvoiceFinalized(details) => {
+                self.invoice_finalized_webhook(&event, details).await?
+            }
+            _ => {
+                log::debug!("Skipping event: {:?}", &event);
+                return Ok(());
+            }
+        };
+
+        let webhook_event_payload = serde_json::to_vec(&webhook_event).map_err(|e| {
+            EventBusError::EventHandlerFailed(format!("Failed to serialize event: {}", e))
+        })?;
+
+        for endpoint in endpoints {
+            let send_result = self
+                .send_webhook_event(&event, &webhook_event, &webhook_event_payload, &endpoint)
+                .await;
+
+            if let Err(e) = send_result {
+                log::error!("{}", e);
+            }
+
+            // todo log attempts into a database table webhook_out_events
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct Endpoint {
+    pub url: String,
+    pub secret: String,
+    pub event_types: Vec<WebhookOutEventTypeEnum>,
+}
+
+#[derive(Serialize)]
+struct WebhookEvent {
+    #[serde(rename = "type")]
+    pub event_type: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    pub data: serde_json::Value,
+}
+
+#[derive(Serialize)]
+struct CustomerData {
+    pub name: String,
+    pub email: Option<String>,
+    pub invoicing_email: Option<String>,
+    pub phone: Option<String>,
+    pub balance_value_cents: i32,
+}
+
+#[derive(Serialize)]
+struct SubscriptionData {
+    pub customer_name: String,
+    pub billing_day: i16,
+    pub billing_start_date: chrono::NaiveDate,
+    pub billing_end_date: Option<chrono::NaiveDate>,
+    pub currency: String,
+    pub net_terms: i32,
+}
+
+#[derive(Serialize)]
+struct InvoiceData {
+    pub customer_name: String,
+    pub currency: String,
+    pub status: String,
+    pub invoice_date: chrono::NaiveDate,
+    pub amount_cents: Option<i64>,
+    pub plan_name: String,
+}
+
+fn to_json<T: Serialize>(data: T) -> Result<serde_json::Value, EventBusError> {
+    serde_json::to_value(data).map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))
+}
+
+fn get_event_type(event: &Event) -> Option<WebhookOutEventTypeEnum> {
+    match &event.event_data {
+        EventData::CustomerCreated(_) => Some(WebhookOutEventTypeEnum::CUSTOMER_CREATED),
+        EventData::SubscriptionCreated(_) => Some(WebhookOutEventTypeEnum::SUBSCRIPTION_CREATED),
+        EventData::InvoiceCreated(_) => Some(WebhookOutEventTypeEnum::INVOICE_CREATED),
+        EventData::InvoiceFinalized(_) => Some(WebhookOutEventTypeEnum::INVOICE_FINALIZED),
+        _ => None,
+    }
+}
+
+fn get_tenant_event_details(event: &Event) -> Option<&TenantEventDataDetails> {
+    match &event.event_data {
+        EventData::CustomerCreated(d) => Some(d),
+        EventData::SubscriptionCreated(d) => Some(d),
+        EventData::InvoiceCreated(d) => Some(d),
+        EventData::InvoiceFinalized(d) => Some(d),
+        _ => None,
+    }
+}
+
+#[tracing::instrument(skip_all)]
+async fn get_active_endpoints_by_tenant(
+    pool: Pool,
+    tenant_id: &Uuid,
+    crypt_key: &SecretString,
+) -> Result<Vec<Endpoint>, EventBusError> {
+    let conn = pool
+        .get()
+        .await
+        .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
+
+    let endpoints: Vec<Endpoint> = meteroid_repository::webhook_out_endpoints::list_endpoints()
+        .bind(&conn, tenant_id)
+        .all()
+        .await
+        .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?
+        .into_iter()
+        .filter_map(|e| {
+            if e.enabled {
+                let secret = crate::crypt::decrypt(crypt_key, e.secret.as_str()).ok()?;
+
+                Some(Endpoint {
+                    url: e.url,
+                    secret: secret.expose_secret().to_string(),
+                    event_types: e.events_to_listen,
+                })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<Endpoint>>();
+
+    Ok(endpoints)
+}
+
+#[tracing::instrument(skip_all)]
+#[cached(
+  result = true,
+  size = 20,
+  time = 120, // 2 min
+  key = "String",
+  convert = r#"{ tenant_id.to_string() }"#
+)]
+async fn get_active_endpoints_by_tenant_cached(
+    pool: Pool,
+    tenant_id: &Uuid,
+    crypt_key: &SecretString,
+) -> Result<Vec<Endpoint>, EventBusError> {
+    get_active_endpoints_by_tenant(pool, tenant_id, crypt_key).await
+}

--- a/modules/meteroid/src/lib.rs
+++ b/modules/meteroid/src/lib.rs
@@ -6,6 +6,7 @@ pub mod crypt;
 pub mod db;
 pub mod encoding;
 mod errors;
+pub mod eventbus;
 pub mod mapping;
 pub mod models;
 pub mod repo;

--- a/modules/meteroid/tests/integration/test_webhooks_out.rs
+++ b/modules/meteroid/tests/integration/test_webhooks_out.rs
@@ -1,8 +1,13 @@
+use chrono::DateTime;
+use meteroid::eventbus::webhook_handler::WebhookHandler;
+use meteroid::eventbus::{Event, EventHandler};
+use std::str::FromStr;
 use testcontainers::clients::Cli;
 
 use crate::helpers;
 use crate::meteroid_it;
 use crate::meteroid_it::container::SeedLevel;
+use crate::meteroid_it::db::seed::{CUSTOMER_UBER_ID, SUBSCRIPTION_SPORTIFY_ID1, TENANT_ID};
 use meteroid_grpc::meteroid::api;
 use meteroid_grpc::meteroid::api::users::v1::UserRole;
 
@@ -66,4 +71,176 @@ async fn test_webhook_endpoint_out() {
     assert_eq!(listed[0], created);
     // teardown
     meteroid_it::container::terminate_meteroid(setup.token, setup.join_handle).await
+}
+
+#[tokio::test]
+async fn test_webhook_out_handler() {
+    // Generic setup
+    helpers::init::logging();
+    let docker = Cli::default();
+    let (_postgres_container, postgres_connection_string) =
+        meteroid_it::container::start_postgres(&docker);
+    let setup = meteroid_it::container::start_meteroid(
+        postgres_connection_string,
+        SeedLevel::SUBSCRIPTIONS,
+    )
+    .await;
+
+    let mut endpoint_server1 = mockito::Server::new();
+    let endpoint_url1 = endpoint_server1.url();
+
+    let mut endpoint_server2 = mockito::Server::new();
+    let endpoint_url2 = endpoint_server2.url();
+
+    let auth = meteroid_it::svc_auth::login(setup.channel.clone()).await;
+    assert_eq!(auth.user.unwrap().role, UserRole::Admin as i32);
+
+    let clients = meteroid_it::clients::AllClients::from_channel(
+        setup.channel.clone(),
+        auth.token.clone().as_str(),
+        "a712afi5lzhk",
+    );
+
+    // create endpoint 1
+    let _ = clients
+        .webhooks_out
+        .clone()
+        .create_webhook_endpoint(api::webhooks::out::v1::CreateWebhookEndpointRequest {
+            url: endpoint_url1,
+            description: Some("Test".to_string()),
+            events_to_listen: vec![
+                api::webhooks::out::v1::WebhookEventType::CustomerCreated as i32,
+                api::webhooks::out::v1::WebhookEventType::SubscriptionCreated as i32,
+            ],
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .endpoint
+        .unwrap();
+
+    // create endpoint 2
+    let _ = clients
+        .webhooks_out
+        .clone()
+        .create_webhook_endpoint(api::webhooks::out::v1::CreateWebhookEndpointRequest {
+            url: endpoint_url2,
+            description: Some("Test".to_string()),
+            events_to_listen: vec![
+                api::webhooks::out::v1::WebhookEventType::CustomerCreated as i32,
+                api::webhooks::out::v1::WebhookEventType::SubscriptionCreated as i32,
+            ],
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .endpoint
+        .unwrap();
+
+    let handler = WebhookHandler::new(
+        setup.pool.clone(),
+        setup.config.secrets_crypt_key.clone(),
+        false,
+    );
+
+    test_webhook_subscription_created_handler(
+        &mut endpoint_server1,
+        &mut endpoint_server2,
+        &handler,
+    )
+    .await;
+
+    test_webhook_customer_created_handler(&mut endpoint_server1, &mut endpoint_server2, &handler)
+        .await;
+
+    // teardown
+    meteroid_it::container::terminate_meteroid(setup.token, setup.join_handle).await
+}
+
+async fn test_webhook_subscription_created_handler(
+    endpoint_server1: &mut mockito::Server,
+    endpoint_server2: &mut mockito::Server,
+    handler: &WebhookHandler,
+) {
+    let event = Event {
+        event_id: uuid::Uuid::from_str("de88623b-a85b-48a6-8720-bc656a9107c7").unwrap(),
+        event_timestamp: DateTime::parse_from_rfc3339("2024-01-01T23:22:15Z")
+            .unwrap()
+            .to_utc(),
+        event_data: meteroid::eventbus::EventData::SubscriptionCreated(
+            meteroid::eventbus::TenantEventDataDetails {
+                tenant_id: TENANT_ID,
+                entity_id: SUBSCRIPTION_SPORTIFY_ID1,
+            },
+        ),
+    };
+
+    fn endpoint_mock(endpoint_server: &mut mockito::Server) -> mockito::Mock {
+        endpoint_server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_header("webhook-id", "de88623b-a85b-48a6-8720-bc656a9107c7")
+            .match_header("webhook-timestamp", "1704151335")
+            .match_header("webhook-signature", mockito::Matcher::Regex(r"v1,.*".to_string()))
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"type":"subscription.created","timestamp":"2024-01-01T23:22:15Z","data":{"billing_day":1,"billing_end_date":null,"billing_start_date":"2023-11-04","currency":"EUR","customer_name":"Sportify","net_terms":0}}"#.to_string(),
+            ))
+            .with_status(201)
+            .create()
+    }
+
+    let endpoint_mock1 = endpoint_mock(endpoint_server1);
+    let endpoint_mock2 = endpoint_mock(endpoint_server2);
+
+    let _ = handler.handle(event).await.unwrap();
+
+    endpoint_mock1.assert();
+    endpoint_mock1.remove();
+
+    endpoint_mock2.assert();
+    endpoint_mock2.remove();
+}
+
+async fn test_webhook_customer_created_handler(
+    endpoint_server1: &mut mockito::Server,
+    endpoint_server2: &mut mockito::Server,
+    handler: &WebhookHandler,
+) {
+    let event = Event {
+        event_id: uuid::Uuid::from_str("de88623b-a85b-48a6-8720-bc656a9107c8").unwrap(),
+        event_timestamp: DateTime::parse_from_rfc3339("2024-02-01T23:22:15Z")
+            .unwrap()
+            .to_utc(),
+        event_data: meteroid::eventbus::EventData::CustomerCreated(
+            meteroid::eventbus::TenantEventDataDetails {
+                tenant_id: TENANT_ID,
+                entity_id: CUSTOMER_UBER_ID,
+            },
+        ),
+    };
+
+    fn endpoint_mock(endpoint_server: &mut mockito::Server) -> mockito::Mock {
+        endpoint_server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_header("webhook-id", "de88623b-a85b-48a6-8720-bc656a9107c8")
+            .match_header("webhook-timestamp", "1706829735")
+            .match_header("webhook-signature", mockito::Matcher::Regex(r"v1,.*".to_string()))
+            .match_body(mockito::Matcher::JsonString(
+                r#"{"type":"customer.created","timestamp":"2024-02-01T23:22:15Z","data":{"balance_value_cents":0,"email":null,"invoicing_email":null,"name":"Uber","phone":null}}"#.to_string(),
+            ))
+            .with_status(201)
+            .create()
+    }
+
+    let endpoint_mock1 = endpoint_mock(endpoint_server1);
+    let endpoint_mock2 = endpoint_mock(endpoint_server2);
+
+    let _ = handler.handle(event).await.unwrap();
+
+    endpoint_mock1.assert();
+    endpoint_mock1.remove();
+
+    endpoint_mock2.assert();
+    endpoint_mock2.remove();
 }


### PR DESCRIPTION
## Description
I tried to find some crate that has similar functionality but failed to find one that's actively maintained so decided to write our own :)
 The idea is to have an event bus with multiple subscribers, starting with webhook_event_sender and segment_event_handler.

- [x] added webhook handler
- [x] publish  (customer.created + subscription.created)

I will add invoice publisher on the next pr, merging this allows to work on segment handler.

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
