### PR TITLE
refactor: default formatting of BuildInfo

### DIFF
--- a/crates/common-build-info/src/lib.rs
+++ b/crates/common-build-info/src/lib.rs
@@ -1,3 +1,5 @@
+use std::fmt::Formatter;
+
 #[derive(Debug, Clone)]
 pub struct BuildInfo {
     pub name: String,
@@ -8,6 +10,22 @@ pub struct BuildInfo {
     pub target_os: String,
     pub target_arch: String,
     pub git_info: String,
+}
+
+impl std::fmt::Display for BuildInfo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} [{}] ({}) {}-{}-{}",
+            self.name,
+            self.version,
+            self.profile,
+            self.git_info,
+            self.target_family,
+            self.target_os,
+            self.target_arch,
+        )
+    }
 }
 
 impl BuildInfo {

--- a/modules/metering/src/bin/server.rs
+++ b/modules/metering/src/bin/server.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }?;
 
     let build_info = BuildInfo::set(env!("CARGO_BIN_NAME"));
-    println!("Starting {:?}", build_info);
+    println!("Starting {}", build_info);
 
     let config = Config::init_from_env().map_err(|err| err)?;
 

--- a/modules/meteroid/src/bin/scheduler.rs
+++ b/modules/meteroid/src/bin/scheduler.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     dotenvy::dotenv().ok();
 
     let build_info = BuildInfo::set(env!("CARGO_BIN_NAME"));
-    println!("Starting {:?}", build_info);
+    println!("Starting {}", build_info);
 
     let config = Config::get();
     let pool = get_pool();

--- a/modules/meteroid/src/bin/server.rs
+++ b/modules/meteroid/src/bin/server.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }?;
 
     let build_info = BuildInfo::set(env!("CARGO_BIN_NAME"));
-    println!("Starting {:?}", build_info);
+    println!("Starting {}", build_info);
 
     let config = Config::get();
 


### PR DESCRIPTION
## Description
Example  of new app startup line
```
Starting meteroid-api v0.1.0 [debug] (e18ab8f38c9de75de32809e2ff81d9bcd332c662.+ (main)) unix-macos-aarch64
```

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
