### PR TITLE
feat: extension to unwrap Result and log message

### DIFF
--- a/crates/common-logging/Cargo.toml
+++ b/crates/common-logging/Cargo.toml
@@ -19,4 +19,5 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 init-tracing-opentelemetry = { workspace = true }
 once_cell = { workspace = true }
+log = { workspace = true }
 

--- a/crates/common-logging/src/lib.rs
+++ b/crates/common-logging/src/lib.rs
@@ -1,9 +1,10 @@
-pub mod init;
-mod init_metrics;
-
 use once_cell::sync::Lazy;
 use opentelemetry::global::meter;
 use opentelemetry::metrics::*;
 pub use opentelemetry::KeyValue;
+
+pub mod init;
+mod init_metrics;
+pub mod unwrapper;
 
 pub static GLOBAL_METER: Lazy<Meter> = Lazy::new(|| meter("METEROID"));

--- a/crates/common-logging/src/unwrapper.rs
+++ b/crates/common-logging/src/unwrapper.rs
@@ -1,0 +1,50 @@
+use log::{logger, Level, MetadataBuilder, Record};
+
+// Extension to log and swallow error
+pub trait UnwrapLogger<T, E>: Sized {
+    fn unwrap_to_log<F: FnOnce(E) -> String>(self, level: Level, msg: F);
+
+    #[inline(always)]
+    #[track_caller]
+    fn unwrap_to_log_error<F: FnOnce(E) -> String>(self, msg: F) {
+        self.unwrap_to_log(Level::Error, msg)
+    }
+
+    #[inline(always)]
+    #[track_caller]
+    fn unwrap_to_log_warn<F: FnOnce(E) -> String>(self, msg: F) {
+        self.unwrap_to_log(Level::Warn, msg)
+    }
+}
+
+impl<T, E> UnwrapLogger<T, E> for Result<T, E> {
+    #[inline(always)]
+    #[track_caller]
+    fn unwrap_to_log<F: FnOnce(E) -> String>(self, level: Level, msg: F) {
+        match self {
+            Ok(_) => (),
+            Err(err) => log_message(level, msg(err)),
+        }
+    }
+}
+
+#[inline(always)]
+#[track_caller]
+fn log_message(level: Level, msg: String) {
+    let loc = std::panic::Location::caller();
+
+    logger().log(
+        &Record::builder()
+            .metadata(
+                MetadataBuilder::new()
+                    .target(loc.file())
+                    .level(level)
+                    .build(),
+            )
+            .args(format_args!("{}", msg))
+            .file(Some(loc.file()))
+            .line(Some(loc.line()))
+            // .level(level)
+            .build(),
+    );
+}


### PR DESCRIPTION
## Description
Extension for `Result` which should be used in cases when we need to log only `Err`

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
