### PR TITLE
feat: add a store/service layer (meteroid-store) and its domain mapping with diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     "modules/meteroid/crates/meteroid-repository",
     "modules/meteroid/crates/stripe-client",
     "modules/meteroid/crates/diesel-models",
-    #    "modules/meteroid/crates/meteroid-store",
+    "modules/meteroid/crates/meteroid-store",
     # metering
     "modules/metering",
     "modules/metering/crates/metering-grpc",
@@ -178,4 +178,4 @@ distributed-lock = { path = "crates/distributed-lock" }
 kafka = { path = "crates/kafka" }
 metering = { path = "modules/metering" }
 diesel-models = { path = "modules/meteroid/crates/diesel-models" }
-#meteroid-store = { path = "modules/meteroid/crates/meteroid-store" }
+meteroid-store = { path = "modules/meteroid/crates/meteroid-store" }

--- a/modules/meteroid/crates/meteroid-store/Cargo.toml
+++ b/modules/meteroid/crates/meteroid-store/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "meteroid-store"
+version = "0.1.0"
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+chrono.workspace = true
+diesel.workspace = true
+diesel-async.workspace = true
+uuid = { workspace = true, features = ["serde"] }
+dotenvy.workspace = true
+tracing.workspace = true
+tracing-log = { workspace = true }
+tracing-subscriber.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+o2o.workspace = true
+error-stack.workspace = true
+thiserror.workspace = true
+diesel-models.workspace = true
+async-trait.workspace = true
+rust_decimal.workspace = true
+rust_decimal_macros.workspace = true
+common-utils = { workspace = true, features = ["decimal"] }
+itertools.workspace = true
+
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/modules/meteroid/crates/meteroid-store/src/domain/billable_metrics.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/billable_metrics.rs
@@ -1,0 +1,52 @@
+use super::enums::{BillingMetricAggregateEnum, UnitConversionRoundingEnum};
+use chrono::NaiveDateTime;
+
+use diesel_models::billable_metrics::{
+    BillableMetric as DieselBillableMetric, BillableMetricNew as DieselBillableMetricNew,
+};
+use o2o::o2o;
+use uuid::Uuid;
+
+#[derive(Clone, Debug, o2o)]
+#[from_owned(DieselBillableMetric)]
+#[owned_into(DieselBillableMetric)]
+pub struct BillableMetric {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub code: String,
+    #[map(~.into())]
+    pub aggregation_type: BillingMetricAggregateEnum,
+    pub aggregation_key: Option<String>,
+    pub unit_conversion_factor: Option<i32>,
+    #[map(~.map(|x| x.into()))]
+    pub unit_conversion_rounding: Option<UnitConversionRoundingEnum>,
+    pub segmentation_matrix: Option<serde_json::Value>,
+    pub usage_group_key: Option<String>,
+    pub created_at: NaiveDateTime,
+    pub created_by: Uuid,
+    pub updated_at: Option<NaiveDateTime>,
+    pub archived_at: Option<NaiveDateTime>,
+    pub tenant_id: Uuid,
+    pub product_family_id: Uuid,
+}
+
+#[derive(Clone, Debug, o2o)]
+#[owned_into(DieselBillableMetricNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct BillableMetricNew {
+    pub name: String,
+    pub description: Option<String>,
+    pub code: String,
+    #[into(~.into())]
+    pub aggregation_type: BillingMetricAggregateEnum,
+    pub aggregation_key: Option<String>,
+    pub unit_conversion_factor: Option<i32>,
+    #[into(~.map(|x| x.into()))]
+    pub unit_conversion_rounding: Option<UnitConversionRoundingEnum>,
+    pub segmentation_matrix: Option<serde_json::Value>,
+    pub usage_group_key: Option<String>,
+    pub created_by: Uuid,
+    pub tenant_id: Uuid,
+    pub product_family_id: Uuid,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/customers.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/customers.rs
@@ -1,0 +1,44 @@
+use chrono::NaiveDateTime;
+use o2o::o2o;
+use uuid::Uuid;
+#[derive(Clone, Debug, o2o)]
+#[from_owned(diesel_models::customers::Customer)]
+#[owned_into(diesel_models::customers::Customer)]
+pub struct Customer {
+    pub id: Uuid,
+    pub name: String,
+    pub created_at: NaiveDateTime,
+    pub created_by: Uuid,
+    pub updated_at: Option<NaiveDateTime>,
+    pub updated_by: Option<Uuid>,
+    pub archived_at: Option<NaiveDateTime>,
+    pub tenant_id: Uuid,
+    pub billing_config: Option<serde_json::Value>,
+    pub alias: Option<String>,
+    pub email: Option<String>,
+    pub invoicing_email: Option<String>,
+    pub phone: Option<String>,
+    pub balance_value_cents: i32,
+    pub balance_currency: String,
+    pub billing_address: Option<serde_json::Value>,
+    pub shipping_address: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, o2o)]
+#[owned_into(diesel_models::customers::CustomerNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct CustomerNew {
+    pub name: String,
+    pub created_by: Uuid,
+    pub tenant_id: Uuid,
+    pub billing_config: Option<serde_json::Value>,
+    pub alias: Option<String>,
+    pub email: Option<String>,
+    pub invoicing_email: Option<String>,
+    pub phone: Option<String>,
+    pub balance_value_cents: i32,
+    pub balance_currency: String,
+    pub billing_address: Option<serde_json::Value>, // TODO avoid json
+    pub shipping_address: Option<serde_json::Value>,
+    pub created_at: Option<NaiveDateTime>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
@@ -1,0 +1,209 @@
+use diesel_models::enums as diesel_enums;
+use o2o::o2o;
+use serde::{Deserialize, Serialize};
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::BillingMetricAggregateEnum)]
+pub enum BillingMetricAggregateEnum {
+    Count,
+    Latest,
+    Max,
+    Min,
+    Mean,
+    Sum,
+    CountDistinct,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[map_owned(diesel_enums::BillingPeriodEnum)]
+pub enum BillingPeriodEnum {
+    Monthly,
+    Quarterly,
+    Annual,
+}
+
+impl BillingPeriodEnum {
+    pub fn as_months(&self) -> u32 {
+        match self {
+            BillingPeriodEnum::Monthly => 1,
+            BillingPeriodEnum::Quarterly => 3,
+            BillingPeriodEnum::Annual => 12,
+        }
+    }
+
+    pub fn as_subscription_billing_period(&self) -> SubscriptionFeeBillingPeriod {
+        match self {
+            BillingPeriodEnum::Monthly => SubscriptionFeeBillingPeriod::Monthly,
+            BillingPeriodEnum::Quarterly => SubscriptionFeeBillingPeriod::Quarterly,
+            BillingPeriodEnum::Annual => SubscriptionFeeBillingPeriod::Annual,
+        }
+    }
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::CreditNoteStatus)]
+pub enum CreditNoteStatus {
+    Draft,
+    Finalized,
+    Voided,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::FangTaskState)]
+pub enum FangTaskState {
+    New,
+    InProgress,
+    Failed,
+    Finished,
+    Retried,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::InvoiceExternalStatusEnum)]
+pub enum InvoiceExternalStatusEnum {
+    Deleted,
+    Draft,
+    Finalized,
+    Paid,
+    PaymentFailed,
+    Uncollectible,
+    Void,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::InvoiceStatusEnum)]
+pub enum InvoiceStatusEnum {
+    Draft,
+    Finalized,
+    Pending,
+    Void,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[map_owned(diesel_enums::InvoiceType)]
+pub enum InvoiceType {
+    Recurring,
+    OneOff,
+    Adjustment,
+    Imported,
+    UsageThreshold,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::InvoicingProviderEnum)]
+pub enum InvoicingProviderEnum {
+    Stripe,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::MrrMovementType)]
+pub enum MrrMovementType {
+    NewBusiness,
+    Expansion,
+    Contraction,
+    Churn,
+    Reactivation,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::OrganizationUserRole)]
+pub enum OrganizationUserRole {
+    Admin,
+    Member,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Default, Clone)]
+#[map_owned(diesel_enums::PlanStatusEnum)]
+pub enum PlanStatusEnum {
+    #[default]
+    Draft,
+    Active,
+    Inactive,
+    Archived,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
+#[map_owned(diesel_enums::PlanTypeEnum)]
+pub enum PlanTypeEnum {
+    Standard,
+    #[default]
+    Free,
+    Custom,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::UnitConversionRoundingEnum)]
+pub enum UnitConversionRoundingEnum {
+    Up,
+    Down,
+    Nearest,
+    NearestHalf,
+    NearestDecile,
+    None,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::WebhookOutEventTypeEnum)]
+pub enum WebhookOutEventTypeEnum {
+    CustomerCreated,
+    SubscriptionCreated,
+    InvoiceCreated,
+    InvoiceFinalized,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::SubscriptionEventType)]
+pub enum SubscriptionEventType {
+    Created,
+    Activated,
+    Switch,
+    Cancelled,
+    Reactivated,
+    Updated,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[map_owned(diesel_enums::SubscriptionFeeBillingPeriod)]
+pub enum SubscriptionFeeBillingPeriod {
+    OneTime,
+    Monthly,
+    Quarterly,
+    Annual,
+}
+
+impl SubscriptionFeeBillingPeriod {
+    pub fn as_months(&self) -> i32 {
+        match self {
+            SubscriptionFeeBillingPeriod::OneTime => i32::MAX, // month_elapsed % OneTime.as_months() will only be 0 if month_elapsed is 0
+            SubscriptionFeeBillingPeriod::Monthly => 1,
+            SubscriptionFeeBillingPeriod::Quarterly => 3,
+            SubscriptionFeeBillingPeriod::Annual => 12,
+        }
+    }
+
+    pub fn as_billing_period_opt(&self) -> Option<BillingPeriodEnum> {
+        match self {
+            SubscriptionFeeBillingPeriod::OneTime => None,
+            SubscriptionFeeBillingPeriod::Monthly => Some(BillingPeriodEnum::Monthly),
+            SubscriptionFeeBillingPeriod::Quarterly => Some(BillingPeriodEnum::Quarterly),
+            SubscriptionFeeBillingPeriod::Annual => Some(BillingPeriodEnum::Annual),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum BillingType {
+    Advance,
+    Arrears,
+}
+
+#[derive(o2o, Serialize, Deserialize, Debug, Clone)]
+#[map_owned(diesel_enums::TenantEnvironmentEnum)]
+pub enum TenantEnvironmentEnum {
+    Production,
+    Staging,
+    Qa,
+    Development,
+    Sandbox,
+    Demo,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/invoices.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/invoices.rs
@@ -1,0 +1,71 @@
+use super::enums::{
+    InvoiceExternalStatusEnum, InvoiceStatusEnum, InvoiceType, InvoicingProviderEnum,
+};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use diesel_models::invoices::Invoice as DieselInvoice;
+use diesel_models::invoices::InvoiceNew as DieselInvoiceNew;
+use o2o::o2o;
+use uuid::Uuid;
+#[derive(Debug, Clone, o2o)]
+#[from_owned(DieselInvoice)]
+pub struct Invoice {
+    pub id: Uuid,
+    #[from(~.into())]
+    pub status: InvoiceStatusEnum,
+    #[from(~.map(|x| x.into()))]
+    pub external_status: Option<InvoiceExternalStatusEnum>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: Option<DateTime<Utc>>,
+    pub tenant_id: Uuid,
+    pub customer_id: Uuid,
+    pub subscription_id: Uuid,
+    pub currency: String,
+    pub days_until_due: Option<i32>,
+    pub external_invoice_id: Option<String>,
+    pub invoice_id: Option<String>,
+    #[from(~.into())]
+    pub invoicing_provider: InvoicingProviderEnum,
+    pub line_items: serde_json::Value,
+    pub issued: bool,
+    pub issue_attempts: i32,
+    pub last_issue_attempt_at: Option<DateTime<Utc>>,
+    pub last_issue_error: Option<String>,
+    pub data_updated_at: Option<NaiveDateTime>,
+    pub invoice_date: NaiveDate,
+    pub amount_cents: Option<i64>,
+    pub plan_version_id: Option<Uuid>,
+    #[from(~.into())]
+    pub invoice_type: InvoiceType,
+    pub finalized_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, o2o)]
+#[owned_into(DieselInvoiceNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct InvoiceNew {
+    #[into(~.into())]
+    pub status: InvoiceStatusEnum,
+    #[into(~.map(|x| x.into()))]
+    pub external_status: Option<InvoiceExternalStatusEnum>,
+    pub tenant_id: Uuid,
+    pub customer_id: Uuid,
+    pub subscription_id: Uuid,
+    pub currency: String,
+    pub days_until_due: Option<i32>,
+    pub external_invoice_id: Option<String>,
+    pub invoice_id: Option<String>,
+    #[into(~.into())]
+    pub invoicing_provider: InvoicingProviderEnum,
+    pub line_items: serde_json::Value,
+    pub issued: bool,
+    pub issue_attempts: i32,
+    pub last_issue_attempt_at: Option<DateTime<Utc>>,
+    pub last_issue_error: Option<String>,
+    pub data_updated_at: Option<NaiveDateTime>,
+    pub invoice_date: NaiveDate,
+    pub amount_cents: Option<i64>,
+    pub plan_version_id: Option<Uuid>,
+    #[into(~.into())]
+    pub invoice_type: InvoiceType,
+    pub finalized_at: Option<NaiveDateTime>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/misc.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/misc.rs
@@ -1,0 +1,105 @@
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+pub struct PaginationRequest {
+    pub per_page: Option<u32>,
+    pub page: u32,
+}
+
+impl Into<diesel_models::extend::pagination::PaginationRequest> for PaginationRequest {
+    fn into(self) -> diesel_models::extend::pagination::PaginationRequest {
+        diesel_models::extend::pagination::PaginationRequest {
+            per_page: self.per_page,
+            page: self.page,
+        }
+    }
+}
+
+pub struct PaginatedVec<T> {
+    pub items: Vec<T>,
+    pub total_pages: u32,
+    pub total_results: u64,
+}
+
+impl<T> Into<PaginatedVec<T>> for diesel_models::extend::pagination::PaginatedVec<T> {
+    fn into(self) -> PaginatedVec<T> {
+        PaginatedVec {
+            items: self.items.into_iter().map(|x| x.into()).collect(),
+            total_pages: self.total_pages,
+            total_results: self.total_results,
+        }
+    }
+}
+
+pub struct CursorPaginationRequest {
+    pub limit: Option<u32>,
+    pub cursor: Option<Uuid>,
+}
+
+impl Into<diesel_models::extend::cursor_pagination::CursorPaginationRequest>
+    for CursorPaginationRequest
+{
+    fn into(self) -> diesel_models::extend::cursor_pagination::CursorPaginationRequest {
+        diesel_models::extend::cursor_pagination::CursorPaginationRequest {
+            limit: self.limit,
+            cursor: self.cursor,
+        }
+    }
+}
+
+pub struct CursorPaginatedVec<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<Uuid>,
+    pub total: i64,
+}
+
+impl<T> Into<CursorPaginatedVec<T>>
+    for diesel_models::extend::cursor_pagination::CursorPaginatedVec<T>
+{
+    fn into(self) -> CursorPaginatedVec<T> {
+        CursorPaginatedVec {
+            items: self.items,
+            next_cursor: self.next_cursor,
+            total: self.total,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TenantContext {
+    // pub actor: Actor, // TODO
+    pub actor: Uuid,
+    pub tenant_id: Uuid,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct OrganizationContext {
+    pub actor: Actor,
+    pub organization_id: Uuid,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Context {
+    pub actor: Actor,
+    pub tenant_id: Option<Uuid>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Actor {
+    System,
+    User(Uuid),
+    ApiKey(Uuid),
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct Period {
+    pub start: NaiveDate,
+    pub end: NaiveDate,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentPeriods {
+    pub arrear: Option<Period>,
+    pub advance: Option<Period>,
+    pub proration_factor: Option<f64>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/mod.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/mod.rs
@@ -1,0 +1,26 @@
+pub mod customers;
+pub mod invoices;
+pub mod plans;
+
+pub mod price_components;
+pub mod tenants;
+
+pub mod billable_metrics;
+pub mod enums;
+pub mod misc;
+pub mod product_families;
+pub mod schedules;
+pub mod subscription_components;
+pub mod subscriptions;
+
+pub use billable_metrics::*;
+pub use customers::*;
+pub use invoices::*;
+pub use misc::*;
+pub use plans::*;
+pub use price_components::*;
+pub use product_families::*;
+pub use schedules::*;
+pub use subscription_components::*;
+pub use subscriptions::*;
+pub use tenants::*;

--- a/modules/meteroid/crates/meteroid-store/src/domain/plans.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/plans.rs
@@ -1,0 +1,119 @@
+use chrono::NaiveDateTime;
+use o2o::o2o;
+use uuid::Uuid;
+// TODO duplicate as well
+use super::enums::{BillingPeriodEnum, PlanStatusEnum, PlanTypeEnum};
+
+use crate::domain::price_components::{PriceComponent, PriceComponentNewInternal};
+
+// not mapped automatically, as we include multiple entities like the plan_version and the price components
+#[derive(Debug, o2o)]
+#[owned_into(diesel_models::plans::PlanNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct PlanNew {
+    pub name: String,
+    pub description: Option<String>,
+    pub created_by: Uuid,
+    pub tenant_id: Uuid,
+    pub product_family_id: Uuid,
+    pub external_id: String,
+    #[into(~.into())]
+    pub plan_type: PlanTypeEnum,
+    #[into(~.into())]
+    pub status: PlanStatusEnum,
+}
+
+pub struct FullPlanNew {
+    pub plan: PlanNew,
+    pub version: PlanVersionNewInternal,
+    pub price_components: Vec<PriceComponentNewInternal>,
+}
+
+#[derive(Debug)]
+pub struct PlanVersionNewInternal {
+    pub is_draft_version: bool,
+    pub trial_duration_days: Option<i32>,
+    pub trial_fallback_plan_id: Option<Uuid>,
+    pub period_start_day: Option<i16>,
+    pub net_terms: i32,
+    pub currency: String,
+    pub billing_cycles: Option<i32>,
+    pub billing_periods: Vec<BillingPeriodEnum>,
+}
+
+#[derive(Debug)]
+pub struct PlanVersionNew {
+    pub plan_id: Uuid,
+    pub created_by: Uuid,
+    pub version: i32,
+    pub tenant_id: Uuid,
+    pub internal: PlanVersionNewInternal,
+}
+
+impl Into<diesel_models::plan_versions::PlanVersionNew> for PlanVersionNew {
+    fn into(self) -> diesel_models::plan_versions::PlanVersionNew {
+        diesel_models::plan_versions::PlanVersionNew {
+            id: Uuid::now_v7(),
+            plan_id: self.plan_id,
+            created_by: self.created_by,
+            version: self.version,
+            tenant_id: self.tenant_id,
+            is_draft_version: self.internal.is_draft_version,
+            trial_duration_days: self.internal.trial_duration_days,
+            trial_fallback_plan_id: self.internal.trial_fallback_plan_id,
+            period_start_day: self.internal.period_start_day,
+            net_terms: self.internal.net_terms,
+            currency: self.internal.currency,
+            billing_cycles: self.internal.billing_cycles,
+            billing_periods: self
+                .internal
+                .billing_periods
+                .into_iter()
+                .map(|v| Some(v.into()))
+                .collect::<Vec<_>>(),
+        }
+    }
+}
+
+#[derive(Debug, o2o)]
+#[from_owned(diesel_models::plans::Plan)]
+pub struct Plan {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    pub created_by: Uuid,
+    pub created_at: NaiveDateTime,
+    pub tenant_id: Uuid,
+    pub product_family_id: Uuid,
+    pub external_id: String,
+    #[from(~.into())]
+    pub plan_type: PlanTypeEnum,
+    #[from(~.into())]
+    pub status: PlanStatusEnum,
+}
+
+#[derive(Debug, o2o)]
+#[from_owned(diesel_models::plan_versions::PlanVersion)]
+pub struct PlanVersion {
+    pub id: Uuid,
+    pub is_draft_version: bool,
+    pub plan_id: Uuid,
+    pub version: i32,
+    pub trial_duration_days: Option<i32>,
+    pub trial_fallback_plan_id: Option<Uuid>,
+    pub tenant_id: Uuid,
+    pub period_start_day: Option<i16>,
+    pub net_terms: i32,
+    pub currency: String,
+    pub billing_cycles: Option<i32>,
+    pub created_at: NaiveDateTime,
+    pub created_by: Uuid,
+    #[from(~.into_iter().filter_map(| v | v).map(| v | v.into()).collect::< Vec < _ >> ())]
+    pub billing_periods: Vec<BillingPeriodEnum>,
+}
+
+pub struct FullPlan {
+    pub plan: Plan,
+    pub version: PlanVersion,
+    pub price_components: Vec<PriceComponent>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/price_components.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/price_components.rs
@@ -1,0 +1,165 @@
+use error_stack::Report;
+
+use uuid::Uuid;
+// TODO duplicate as well
+use super::enums::{BillingPeriodEnum, BillingType};
+
+use crate::errors::StoreError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone)]
+pub struct PriceComponent {
+    pub id: Uuid,
+    pub name: String,
+    pub fee: FeeType,
+    pub product_item_id: Option<Uuid>,
+}
+
+impl TryInto<PriceComponent> for diesel_models::price_components::PriceComponent {
+    type Error = Report<StoreError>;
+
+    fn try_into(self) -> Result<PriceComponent, Self::Error> {
+        let fee: FeeType = serde_json::from_value(self.fee).map_err(|e| {
+            StoreError::SerdeError("Failed to deserialize price component fee".to_string(), e)
+        })?;
+
+        // TODO we also have plan version id and metric id in the type
+        Ok(PriceComponent {
+            id: self.id,
+            name: self.name,
+            fee,
+            product_item_id: self.product_item_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PriceComponentNew {
+    pub name: String,
+    pub fee: FeeType,
+    pub product_item_id: Option<Uuid>,
+    pub plan_version_id: Uuid,
+}
+
+#[derive(Debug, Clone)]
+pub struct PriceComponentNewInternal {
+    pub name: String,
+    pub fee: FeeType,
+    pub product_item_id: Option<Uuid>,
+}
+
+impl TryInto<diesel_models::price_components::PriceComponentNew> for PriceComponentNew {
+    type Error = StoreError;
+
+    fn try_into(self) -> Result<diesel_models::price_components::PriceComponentNew, StoreError> {
+        let json_fee = serde_json::to_value(&self.fee)
+            .map_err(|e| {
+                StoreError::SerdeError("Failed to serialize price component fee".to_string(), e)
+            })
+            .unwrap();
+
+        Ok(diesel_models::price_components::PriceComponentNew {
+            id: Uuid::now_v7(),
+            plan_version_id: self.plan_version_id,
+            name: self.name,
+            fee: json_fee,
+            product_item_id: self.product_item_id,
+            billable_metric_id: self.fee.metric_id(),
+        })
+    }
+}
+
+//
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum UsagePricingModel {
+    PerUnit {
+        rate: rust_decimal::Decimal,
+    },
+    Tiered {
+        tiers: Vec<TierRow>,
+        block_size: Option<u64>,
+    },
+    Volume {
+        tiers: Vec<TierRow>,
+        block_size: Option<u64>,
+    },
+    Package {
+        block_size: u64,
+        rate: rust_decimal::Decimal,
+    },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TierRow {
+    pub first_unit: u64,
+    // last unit is implicit.
+    pub rate: rust_decimal::Decimal,
+    pub flat_fee: Option<rust_decimal::Decimal>,
+    pub flat_cap: Option<rust_decimal::Decimal>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum FeeType {
+    Rate {
+        rates: Vec<TermRate>,
+    },
+    Slot {
+        rates: Vec<TermRate>,
+        slot_unit_name: String,
+        upgrade_policy: UpgradePolicy,
+        downgrade_policy: DowngradePolicy,
+        minimum_count: Option<u32>,
+        quota: Option<u32>,
+    },
+    Capacity {
+        metric_id: Uuid,
+        thresholds: Vec<CapacityThreshold>,
+    },
+    Usage {
+        metric_id: Uuid,
+        pricing: UsagePricingModel,
+    },
+    ExtraRecurring {
+        unit_price: rust_decimal::Decimal,
+        quantity: u32,
+        billing_type: BillingType,
+        cadence: BillingPeriodEnum,
+    },
+    OneTime {
+        unit_price: rust_decimal::Decimal,
+        quantity: u32,
+    },
+}
+
+impl FeeType {
+    pub fn metric_id(&self) -> Option<Uuid> {
+        match self {
+            FeeType::Capacity { metric_id, .. } => Some(*metric_id),
+            FeeType::Usage { metric_id, .. } => Some(*metric_id),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TermRate {
+    pub term: BillingPeriodEnum,
+    pub price: rust_decimal::Decimal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapacityThreshold {
+    pub included_amount: u64,
+    pub price: rust_decimal::Decimal,
+    pub per_unit_overage: rust_decimal::Decimal,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum UpgradePolicy {
+    Prorated,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum DowngradePolicy {
+    RemoveAtEndOfPeriod,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/product_families.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/product_families.rs
@@ -1,0 +1,28 @@
+use chrono::NaiveDateTime;
+use o2o::o2o;
+use uuid::Uuid;
+
+use diesel_models::product_families::ProductFamily as DieselProductFamily;
+use diesel_models::product_families::ProductFamilyNew as DieselProductFamilyNew;
+
+#[derive(Clone, Debug, o2o)]
+#[from_owned(DieselProductFamily)]
+#[owned_into(DieselProductFamily)]
+pub struct ProductFamily {
+    pub id: Uuid,
+    pub name: String,
+    pub external_id: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: Option<NaiveDateTime>,
+    pub archived_at: Option<NaiveDateTime>,
+    pub tenant_id: Uuid,
+}
+
+#[derive(Clone, Debug, o2o)]
+#[owned_into(DieselProductFamilyNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct ProductFamilyNew {
+    pub name: String,
+    pub external_id: String,
+    pub tenant_id: Uuid,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/schedules.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/schedules.rs
@@ -1,0 +1,26 @@
+use o2o::o2o;
+use uuid::Uuid;
+
+use crate::domain::enums::BillingPeriodEnum;
+use diesel_models::schedules::Schedule as DieselSchedule;
+use diesel_models::schedules::ScheduleNew as DieselScheduleNew;
+
+#[derive(Clone, Debug, o2o)]
+#[map_owned(DieselSchedule)]
+pub struct Schedule {
+    pub id: Uuid,
+    #[map(~.into())]
+    pub billing_period: BillingPeriodEnum,
+    pub plan_version_id: Uuid,
+    pub ramps: serde_json::Value, // TODO
+}
+
+#[derive(Clone, Debug, o2o)]
+#[owned_into(DieselScheduleNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct ScheduleNew {
+    #[into(~.into())]
+    pub billing_period: BillingPeriodEnum,
+    pub plan_version_id: Uuid,
+    pub ramps: serde_json::Value,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/subscription_components.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/subscription_components.rs
@@ -1,0 +1,164 @@
+use super::enums::{BillingPeriodEnum, BillingType, SubscriptionFeeBillingPeriod};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::domain::UsagePricingModel;
+use crate::errors::StoreError;
+use diesel_models::subscription_components as db;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SubscriptionComponent {
+    pub id: Uuid,
+    pub price_component_id: Option<Uuid>,
+    pub product_item_id: Option<Uuid>,
+    pub subscription_id: Uuid,
+    pub name: String,
+    pub period: SubscriptionFeeBillingPeriod,
+    pub fee: SubscriptionFee,
+}
+
+impl TryInto<SubscriptionComponent> for db::SubscriptionComponent {
+    type Error = StoreError;
+
+    fn try_into(self) -> Result<SubscriptionComponent, Self::Error> {
+        let decoded_fee: SubscriptionFee = serde_json::from_value(self.fee)
+            .map_err(|e| StoreError::SerdeError("Failed to deserialize fee".to_string(), e))?;
+
+        Ok(SubscriptionComponent {
+            id: self.id,
+            price_component_id: self.price_component_id,
+            product_item_id: self.product_item_id,
+            subscription_id: self.subscription_id,
+            name: self.name,
+            period: self.period.into(),
+            fee: decoded_fee,
+        })
+    }
+}
+
+impl SubscriptionComponent {
+    pub fn metric_id(&self) -> Option<Uuid> {
+        match &self.fee {
+            SubscriptionFee::Usage { metric_id, .. } => Some(*metric_id),
+            SubscriptionFee::Capacity { metric_id, .. } => Some(*metric_id),
+            _ => None,
+        }
+    }
+
+    /**
+     * Returns true if the component is Rate/Slot/Capacity, false otherwise.
+     */
+    pub fn is_standard(&self) -> bool {
+        match &self.fee {
+            SubscriptionFee::Rate { .. }
+            | SubscriptionFee::Slot { .. }
+            | SubscriptionFee::Capacity { .. } => true,
+            SubscriptionFee::OneTime { .. }
+            | SubscriptionFee::Recurring { .. }
+            | SubscriptionFee::Usage { .. } => false,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SubscriptionComponentNew {
+    pub subscription_id: Uuid,
+    pub internal: SubscriptionComponentNewInternal,
+}
+
+impl TryInto<db::SubscriptionComponentNew> for SubscriptionComponentNew {
+    type Error = StoreError;
+
+    fn try_into(self) -> Result<db::SubscriptionComponentNew, Self::Error> {
+        let fee = serde_json::to_value(self.internal.fee)
+            .map_err(|e| StoreError::SerdeError("Failed to serialize fee".to_string(), e))?;
+
+        Ok(db::SubscriptionComponentNew {
+            id: Uuid::now_v7(),
+            subscription_id: self.subscription_id,
+            price_component_id: self.internal.price_component_id,
+            product_item_id: self.internal.product_item_id,
+            name: self.internal.name,
+            period: self.internal.period.into(),
+            fee,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSubscriptionComponents {
+    pub parameterized_components: Vec<ComponentParameterization>,
+    pub overridden_components: Vec<ComponentOverride>,
+    pub extra_components: Vec<ExtraComponent>,
+    pub remove_components: Vec<Uuid>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentParameterization {
+    pub component_id: Uuid,
+    pub parameters: ComponentParameters,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentParameters {
+    pub initial_slot_count: Option<u32>,
+    pub billing_period: Option<BillingPeriodEnum>,
+    pub committed_capacity: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentOverride {
+    pub component_id: Uuid,
+    pub component: SubscriptionComponentNewInternal,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtraComponent {
+    pub component: SubscriptionComponentNewInternal,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscriptionComponentNewInternal {
+    pub price_component_id: Option<Uuid>,
+    pub product_item_id: Option<Uuid>,
+    pub name: String,
+    pub period: SubscriptionFeeBillingPeriod,
+    // pub mrr_value: Option<rust_decimal::Decimal>, // TODO
+    pub fee: SubscriptionFee,
+    pub is_override: bool,
+}
+
+// TODO golden tests
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub enum SubscriptionFee {
+    Rate {
+        rate: rust_decimal::Decimal,
+    },
+    OneTime {
+        rate: rust_decimal::Decimal,
+        quantity: u32,
+    },
+    Recurring {
+        rate: rust_decimal::Decimal,
+        quantity: u32,
+        billing_type: BillingType,
+    },
+    Capacity {
+        rate: rust_decimal::Decimal,
+        included: u64,
+        overage_rate: rust_decimal::Decimal,
+        metric_id: Uuid,
+    },
+    Slot {
+        unit: String,
+        unit_rate: rust_decimal::Decimal,
+        min_slots: Option<u32>,
+        max_slots: Option<u32>,
+        initial_slots: u32,
+        // upgrade downgrade policies TODO
+    },
+    Usage {
+        metric_id: Uuid,
+        model: UsagePricingModel,
+    },
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/subscriptions.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/subscriptions.rs
@@ -1,0 +1,149 @@
+use chrono::{NaiveDate, NaiveDateTime};
+use o2o::o2o;
+use uuid::Uuid;
+
+use crate::domain::{
+    BillableMetric, CreateSubscriptionComponents, Schedule, SubscriptionComponent,
+};
+use diesel_models::subscriptions::Subscription as DieselSubscription;
+use diesel_models::subscriptions::SubscriptionNew as DieselSubscriptionNew;
+
+#[derive(Debug, o2o)]
+#[from_owned(DieselSubscription)]
+pub struct CreatedSubscription {
+    pub id: Uuid,
+    pub customer_id: Uuid,
+    pub billing_day: i16,
+    pub tenant_id: Uuid,
+    pub currency: String,
+    pub trial_start_date: Option<NaiveDate>,
+    pub billing_start_date: NaiveDate,
+    pub billing_end_date: Option<NaiveDate>,
+    pub plan_version_id: Uuid,
+    pub created_at: NaiveDateTime,
+    pub created_by: Uuid,
+    pub net_terms: i32,
+    pub invoice_memo: Option<String>,
+    pub invoice_threshold: Option<rust_decimal::Decimal>,
+    pub activated_at: Option<NaiveDateTime>,
+    pub canceled_at: Option<NaiveDateTime>,
+    pub cancellation_reason: Option<String>,
+    pub mrr_cents: i64,
+}
+
+#[derive(Debug)]
+pub struct Subscription {
+    pub id: Uuid,
+    pub customer_id: Uuid,
+    pub customer_name: String,
+    pub customer_alias: Option<String>,
+    pub billing_day: i16,
+    pub tenant_id: Uuid,
+    pub currency: String,
+    pub trial_start_date: Option<NaiveDate>,
+    pub billing_start_date: NaiveDate,
+    pub billing_end_date: Option<NaiveDate>,
+    pub plan_id: Uuid,
+    pub plan_name: String,
+    pub plan_version_id: Uuid,
+    pub version: u32,
+    pub created_at: NaiveDateTime,
+    pub created_by: Uuid,
+    // pub created_by_name: String,
+    pub net_terms: u32,
+    pub invoice_memo: Option<String>,
+    pub invoice_threshold: Option<rust_decimal::Decimal>,
+    pub activated_at: Option<NaiveDateTime>,
+    pub canceled_at: Option<NaiveDateTime>,
+    pub cancellation_reason: Option<String>,
+    pub mrr_cents: u64,
+}
+
+impl Into<Subscription> for diesel_models::subscriptions::SubscriptionForDisplay {
+    fn into(self) -> Subscription {
+        Subscription {
+            id: self.subscription.id,
+            customer_id: self.subscription.customer_id,
+            customer_name: self.customer_name,
+            customer_alias: self.customer_external_id,
+            billing_day: self.subscription.billing_day,
+            tenant_id: self.subscription.tenant_id,
+            currency: self.subscription.currency,
+            trial_start_date: self.subscription.trial_start_date,
+            billing_start_date: self.subscription.billing_start_date,
+            billing_end_date: self.subscription.billing_end_date,
+            plan_id: self.plan_id,
+            plan_name: self.plan_name,
+            plan_version_id: self.subscription.plan_version_id,
+            version: self.version as u32,
+            created_at: self.subscription.created_at,
+            created_by: self.subscription.created_by,
+            net_terms: self.subscription.net_terms as u32,
+            invoice_memo: self.subscription.invoice_memo,
+            invoice_threshold: self.subscription.invoice_threshold,
+            activated_at: self.subscription.activated_at,
+            canceled_at: self.subscription.canceled_at,
+            cancellation_reason: self.subscription.cancellation_reason,
+            mrr_cents: self.subscription.mrr_cents as u64,
+        }
+    }
+}
+
+#[derive(Debug, Clone, o2o)]
+#[owned_into(DieselSubscriptionNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()}, mrr_cents: {0})]
+pub struct SubscriptionNew {
+    pub customer_id: Uuid,
+    pub billing_day: i16,
+    pub tenant_id: Uuid,
+    pub currency: String,
+    pub trial_start_date: Option<NaiveDate>,
+    pub billing_start_date: NaiveDate,
+    pub billing_end_date: Option<NaiveDate>,
+    pub plan_version_id: Uuid,
+    pub created_by: Uuid,
+    pub net_terms: i32,
+    pub invoice_memo: Option<String>,
+    pub invoice_threshold: Option<rust_decimal::Decimal>,
+    pub activated_at: Option<NaiveDateTime>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateSubscription {
+    pub subscription: SubscriptionNew,
+    pub price_components: Option<CreateSubscriptionComponents>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubscriptionDetails {
+    pub id: uuid::Uuid,
+    pub tenant_id: uuid::Uuid,
+    pub customer_id: uuid::Uuid,
+    pub plan_version_id: uuid::Uuid,
+    pub customer_external_id: Option<String>,
+    pub billing_start_date: chrono::NaiveDate,
+    pub billing_end_date: Option<chrono::NaiveDate>,
+    pub billing_day: i16,
+
+    pub currency: String,
+    pub net_terms: u32,
+    pub schedules: Vec<Schedule>,
+    pub price_components: Vec<SubscriptionComponent>,
+    pub metrics: Vec<BillableMetric>,
+    pub mrr_cents: u64,
+
+    //
+    pub version: u32,
+    pub plan_name: String,
+    pub plan_id: Uuid,
+    pub customer_name: String,
+    pub canceled_at: Option<chrono::NaiveDateTime>,
+
+    pub invoice_memo: Option<String>,
+    pub invoice_threshold: Option<rust_decimal::Decimal>,
+    pub created_at: chrono::NaiveDateTime,
+    pub cancellation_reason: Option<String>,
+    pub activated_at: Option<chrono::NaiveDateTime>,
+    pub created_by: Uuid,
+    pub trial_start_date: Option<chrono::NaiveDate>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/domain/tenants.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/tenants.rs
@@ -1,0 +1,35 @@
+use chrono::NaiveDateTime;
+use o2o::o2o;
+use uuid::Uuid;
+
+use crate::domain::enums::TenantEnvironmentEnum;
+use diesel_models::tenants::Tenant as DieselTenant;
+use diesel_models::tenants::TenantNew as DieselTenantNew;
+
+#[derive(Clone, Debug, o2o)]
+#[from_owned(DieselTenant)]
+#[owned_into(DieselTenant)]
+pub struct Tenant {
+    pub id: Uuid,
+    pub name: String,
+    pub slug: String,
+    pub created_at: NaiveDateTime,
+    pub updated_at: Option<NaiveDateTime>,
+    pub archived_at: Option<NaiveDateTime>,
+    pub organization_id: Uuid,
+    pub currency: String,
+    #[map(~.into())]
+    pub environment: TenantEnvironmentEnum,
+}
+
+#[derive(Clone, Debug, o2o)]
+#[owned_into(DieselTenantNew)]
+#[ghosts(id: {uuid::Uuid::now_v7()})]
+pub struct TenantNew {
+    pub name: String,
+    pub slug: String,
+    pub organization_id: Uuid,
+    pub currency: String,
+    #[into(~.map(|x| x.into()))]
+    pub environment: Option<TenantEnvironmentEnum>,
+}

--- a/modules/meteroid/crates/meteroid-store/src/errors.rs
+++ b/modules/meteroid/crates/meteroid-store/src/errors.rs
@@ -1,0 +1,19 @@
+use diesel_models::errors::DatabaseError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StoreError {
+    #[error("Initialization Error")]
+    InitializationError,
+    #[error("DatabaseError: {0:?}")]
+    DatabaseError(error_stack::Report<DatabaseError>),
+    #[error("Invalid Argument: {0}")]
+    InvalidArgument(String),
+    #[error("Timed out while trying to connect to the database")]
+    DatabaseConnectionError,
+    #[error("Invalid decimal value")]
+    InvalidDecimal,
+    #[error("Failed to process price components: {0}")]
+    InvalidPriceComponents(String),
+    #[error("Failed to serialize/deserialize data: {0}")]
+    SerdeError(String, #[source] serde_json::Error),
+}

--- a/modules/meteroid/crates/meteroid-store/src/lib.rs
+++ b/modules/meteroid/crates/meteroid-store/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod domain;
+pub mod errors;
+// pub mod repositories;
+pub mod store;
+// pub mod utils;
+
+pub use store::Store;
+
+pub type StoreResult<T> = error_stack::Result<T, errors::StoreError>;

--- a/modules/meteroid/crates/meteroid-store/src/store.rs
+++ b/modules/meteroid/crates/meteroid-store/src/store.rs
@@ -1,0 +1,94 @@
+use crate::errors::StoreError;
+use diesel_async::pooled_connection::deadpool::Object;
+use diesel_async::pooled_connection::deadpool::Pool;
+
+use crate::StoreResult;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::scoped_futures::{ScopedBoxFuture, ScopedFutureExt};
+use diesel_async::{AsyncConnection, AsyncPgConnection};
+use error_stack::{Report, ResultExt};
+
+pub type PgPool = Pool<AsyncPgConnection>;
+pub type PgConn = Object<AsyncPgConnection>;
+
+#[derive(Clone)]
+pub struct Store {
+    pub pool: PgPool,
+}
+
+pub fn diesel_make_pg_pool(db_url: String) -> StoreResult<PgPool> {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(db_url);
+    let builder = Pool::builder(manager);
+
+    builder
+        .build()
+        .map_err(Report::from)
+        .change_context(StoreError::InitializationError)
+        .attach_printable("Failed to create PostgreSQL connection pool")
+}
+
+impl Store {
+    pub fn from_pool(pool: PgPool) -> Self {
+        Store { pool }
+    }
+
+    pub fn new(database_url: String) -> StoreResult<Self> {
+        let pool: PgPool = diesel_make_pg_pool(database_url)?;
+
+        Ok(Store { pool })
+    }
+
+    pub async fn get_conn(&self) -> StoreResult<PgConn> {
+        self.pool
+            .get()
+            .await
+            .map_err(Report::from)
+            .change_context(StoreError::DatabaseConnectionError)
+            .attach_printable("Failed to get a connection from the pool")
+    }
+
+
+    // Temporary, evaluating if this simplifies the handling of store + diesel interations within a transaction
+
+    pub(crate) async fn transaction<'a, R, F>(&self, callback: F) -> StoreResult<R>
+        where
+            F: for<'r> FnOnce(
+                &'r mut PgConn,
+            )
+                -> ScopedBoxFuture<'a, 'r, error_stack::Result<R, StoreError>>
+            + Send
+            + 'a,
+            R: Send + 'a,
+    {
+        let mut conn = self.get_conn().await?;
+
+        self.transaction_with(&mut conn, callback).await
+    }
+
+    pub(crate) async fn transaction_with<'a, R, F>(
+        &self,
+        conn: &mut PgConn,
+        callback: F,
+    ) -> StoreResult<R>
+        where
+            F: for<'r> FnOnce(
+                &'r mut PgConn,
+            )
+                -> ScopedBoxFuture<'a, 'r, error_stack::Result<R, StoreError>>
+            + Send
+            + 'a,
+            R: Send + 'a,
+    {
+        let result = conn
+            .transaction(|conn| {
+                async move {
+                    let res = callback(conn);
+                    res.await.map_err(StoreError::TransactionStoreError)
+                }
+                    .scope_boxed()
+            })
+            .await?;
+
+        Ok(result)
+    }
+}


### PR DESCRIPTION
## Description
Add meteroid-store, with only the domain objects and mappers from/to diesel-models

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
