### PR TITLE
chore: pin pnpm version to fix docker build

### DIFF
--- a/modules/web/web-app/Dockerfile
+++ b/modules/web/web-app/Dockerfile
@@ -13,7 +13,7 @@ RUN (cd modules/web/ && turbo prune --scope=@md/web --docker)
 
 FROM base AS installer
 WORKDIR /app
-RUN yarn global add pnpm turbo
+RUN yarn global add pnpm@8 turbo
 
 COPY --from=builder /app/.gitignore .gitignore
 COPY --from=builder /app/modules/web/web-app/nginx.conf nginx.conf


### PR DESCRIPTION
## Description
Force the pnpm version in docker to 8 (same as repo) until we update everything

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
