### PR TITLE
Fixed minio external port

### DIFF
--- a/docker/develop/docker-compose.yml
+++ b/docker/develop/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - MINIO_ROOT_PASSWORD=${S3_password:-meteroid}
     command: server /data --console-address ":9001"
     ports:
-      - 9000:9000
+      - 9002:9000
       - 9001:9001
     volumes:
       - minio_data:/data


### PR DESCRIPTION
Both minio and clickhouse were using external port 9000. Changed minio to port 9002.
