### PR TITLE
feat(trials): implement trials in plans

### DIFF
--- a/docker/develop/data/README.md
+++ b/docker/develop/data/README.md
@@ -1,4 +1,4 @@
-Use the following credentials to access the sandbox tenant : 
+Use the following credentials to access the sandbox tenant :
 
 demo-user@meteroid.dev
-secret
+sandbox-F3j

--- a/modules/meteroid/crates/diesel-models/src/enums.rs
+++ b/modules/meteroid/crates/diesel-models/src/enums.rs
@@ -1,4 +1,13 @@
 #[derive(diesel_derive_enum::DbEnum, Debug, Clone)]
+#[ExistingTypePath = "crate::schema::sql_types::ActionAfterTrialEnum"]
+#[DbValueStyle = "SCREAMING_SNAKE_CASE"]
+pub enum ActionAfterTrialEnum {
+    Block,
+    Charge,
+    Downgrade,
+}
+
+#[derive(diesel_derive_enum::DbEnum, Debug, Clone)]
 #[ExistingTypePath = "crate::schema::sql_types::BillingMetricAggregateEnum"]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum BillingMetricAggregateEnum {

--- a/modules/meteroid/crates/diesel-models/src/plan_versions.rs
+++ b/modules/meteroid/crates/diesel-models/src/plan_versions.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
-use crate::enums::BillingPeriodEnum;
+use crate::enums::{ActionAfterTrialEnum, BillingPeriodEnum};
 
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
@@ -14,7 +14,7 @@ pub struct PlanVersionRow {
     pub plan_id: Uuid,
     pub version: i32,
     pub trial_duration_days: Option<i32>,
-    pub trial_fallback_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<Uuid>,
     pub tenant_id: Uuid,
     pub period_start_day: Option<i16>,
     pub net_terms: i32,
@@ -23,6 +23,9 @@ pub struct PlanVersionRow {
     pub created_at: NaiveDateTime,
     pub created_by: Uuid,
     pub billing_periods: Vec<Option<BillingPeriodEnum>>,
+    pub trialing_plan_id: Option<Uuid>,
+    pub action_after_trial: Option<ActionAfterTrialEnum>,
+    pub trial_is_free: bool,
 }
 
 #[derive(Debug, Insertable, Default)]
@@ -34,7 +37,7 @@ pub struct PlanVersionRowNew {
     pub plan_id: Uuid,
     pub version: i32,
     pub trial_duration_days: Option<i32>,
-    pub trial_fallback_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<Uuid>,
     pub tenant_id: Uuid,
     pub period_start_day: Option<i16>,
     pub net_terms: i32,
@@ -42,6 +45,9 @@ pub struct PlanVersionRowNew {
     pub billing_cycles: Option<i32>,
     pub created_by: Uuid,
     pub billing_periods: Vec<BillingPeriodEnum>,
+    pub trialing_plan_id: Option<Uuid>,
+    pub action_after_trial: Option<ActionAfterTrialEnum>,
+    pub trial_is_free: bool,
 }
 
 #[derive(Debug, Queryable, Identifiable, Selectable)]
@@ -59,7 +65,10 @@ pub struct PlanVersionRowLatest {
     pub version: i32,
     pub created_by: Uuid,
     pub trial_duration_days: Option<i32>,
-    pub trial_fallback_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<Uuid>,
+    pub trialing_plan_id: Option<Uuid>,
+    pub action_after_trial: Option<ActionAfterTrialEnum>,
+    pub trial_is_free: bool,
     pub period_start_day: Option<i16>,
     pub net_terms: i32,
     pub currency: String,
@@ -81,4 +90,18 @@ pub struct PlanVersionRowPatch {
     pub currency: Option<String>,
     pub net_terms: Option<i32>,
     pub billing_periods: Option<Vec<BillingPeriodEnum>>,
+}
+
+#[derive(Debug, AsChangeset)]
+#[diesel(table_name = crate::schema::plan_version)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+#[diesel(primary_key(id, tenant_id))]
+pub struct PlanVersionTrialRowPatch {
+    pub id: Uuid,
+    pub tenant_id: Uuid,
+    pub trialing_plan_id: Option<Option<Uuid>>,
+    pub action_after_trial: Option<Option<ActionAfterTrialEnum>>,
+    pub trial_is_free: Option<bool>,
+    pub trial_duration_days: Option<Option<i32>>,
+    pub downgrade_plan_id: Option<Option<Uuid>>,
 }

--- a/modules/meteroid/crates/diesel-models/src/plans.rs
+++ b/modules/meteroid/crates/diesel-models/src/plans.rs
@@ -79,3 +79,9 @@ pub struct PlanRowPatch {
     pub name: Option<String>,
     pub description: Option<Option<String>>,
 }
+
+pub struct PlanFilters {
+    pub search: Option<String>,
+    pub filter_status: Option<PlanStatusEnum>,
+    pub filter_type: Option<PlanTypeEnum>,
+}

--- a/modules/meteroid/crates/diesel-models/src/query/plan_versions.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/plan_versions.rs
@@ -1,6 +1,7 @@
 use crate::errors::IntoDbResult;
 use crate::plan_versions::{
     PlanVersionRow, PlanVersionRowLatest, PlanVersionRowNew, PlanVersionRowPatch,
+    PlanVersionTrialRowPatch,
 };
 
 use crate::{DbResult, PgConn};
@@ -253,6 +254,26 @@ impl PlanVersionRowPatch {
             .get_result(conn)
             .await
             .attach_printable("Error while updating plan version")
+            .into_db_result()
+    }
+}
+
+impl PlanVersionTrialRowPatch {
+    pub async fn update_trial(&self, conn: &mut PgConn) -> DbResult<PlanVersionRow> {
+        use crate::schema::plan_version::dsl as pv_dsl;
+        use diesel_async::RunQueryDsl;
+
+        let query = diesel::update(pv_dsl::plan_version)
+            .filter(pv_dsl::id.eq(self.id))
+            .filter(pv_dsl::tenant_id.eq(self.tenant_id))
+            .set(self);
+
+        log::info!("{}", debug_query::<diesel::pg::Pg, _>(&query).to_string());
+
+        query
+            .get_result(conn)
+            .await
+            .attach_printable("Error while updating plan version trial")
             .into_db_result()
     }
 }

--- a/modules/meteroid/crates/diesel-models/src/schema.rs
+++ b/modules/meteroid/crates/diesel-models/src/schema.rs
@@ -2,6 +2,10 @@
 
 pub mod sql_types {
     #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
+    #[diesel(postgres_type(name = "ActionAfterTrialEnum"))]
+    pub struct ActionAfterTrialEnum;
+
+    #[derive(diesel::query_builder::QueryId, diesel::sql_types::SqlType)]
     #[diesel(postgres_type(name = "BillingMetricAggregateEnum"))]
     pub struct BillingMetricAggregateEnum;
 
@@ -472,6 +476,7 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
     use super::sql_types::BillingPeriodEnum;
+    use super::sql_types::ActionAfterTrialEnum;
 
     plan_version (id) {
         id -> Uuid,
@@ -479,7 +484,7 @@ diesel::table! {
         plan_id -> Uuid,
         version -> Int4,
         trial_duration_days -> Nullable<Int4>,
-        trial_fallback_plan_id -> Nullable<Uuid>,
+        downgrade_plan_id -> Nullable<Uuid>,
         tenant_id -> Uuid,
         period_start_day -> Nullable<Int2>,
         net_terms -> Int4,
@@ -488,6 +493,9 @@ diesel::table! {
         created_at -> Timestamp,
         created_by -> Uuid,
         billing_periods -> Array<Nullable<BillingPeriodEnum>>,
+        trialing_plan_id -> Nullable<Uuid>,
+        action_after_trial -> Nullable<ActionAfterTrialEnum>,
+        trial_is_free -> Bool,
     }
 }
 
@@ -760,7 +768,6 @@ diesel::joinable!(organization_member -> organization (organization_id));
 diesel::joinable!(organization_member -> user (user_id));
 diesel::joinable!(plan -> product_family (product_family_id));
 diesel::joinable!(plan -> tenant (tenant_id));
-diesel::joinable!(plan_version -> plan (plan_id));
 diesel::joinable!(price_component -> billable_metric (billable_metric_id));
 diesel::joinable!(price_component -> plan_version (plan_version_id));
 diesel::joinable!(price_component -> product (product_item_id));

--- a/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
@@ -3,6 +3,14 @@ use o2o::o2o;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 
+#[derive(o2o, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+#[map_owned(diesel_enums::ActionAfterTrialEnum)]
+pub enum ActionAfterTrialEnum {
+    Block,
+    Charge,
+    Downgrade,
+}
+
 #[derive(o2o, Serialize, Deserialize, Debug, Clone)]
 #[map_owned(diesel_enums::BillingMetricAggregateEnum)]
 pub enum BillingMetricAggregateEnum {

--- a/modules/meteroid/crates/meteroid-store/src/domain/plans.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/plans.rs
@@ -3,6 +3,7 @@ use diesel_models::plan_versions::PlanVersionRow;
 use diesel_models::plan_versions::PlanVersionRowLatest;
 use diesel_models::plan_versions::PlanVersionRowNew;
 use diesel_models::plan_versions::PlanVersionRowPatch;
+use diesel_models::plans::PlanFilters as PlanFiltersDb;
 use diesel_models::plans::PlanRow;
 use diesel_models::plans::PlanRowForList;
 use diesel_models::plans::PlanRowNew;
@@ -254,4 +255,14 @@ pub struct TrialPatch {
     pub plan_version_id: Uuid,
     pub tenant_id: Uuid,
     pub trial: Option<PlanTrial>,
+}
+
+#[derive(Debug, o2o)]
+#[owned_into(PlanFiltersDb)]
+pub struct PlanFilters {
+    pub search: Option<String>,
+    #[into(~.map(| v | v.into()))]
+    pub filter_status: Option<PlanStatusEnum>,
+    #[into(~.map(| v | v.into()))]
+    pub filter_type: Option<PlanTypeEnum>,
 }

--- a/modules/meteroid/crates/meteroid-store/src/repositories/plans.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/plans.rs
@@ -1,11 +1,10 @@
 use crate::store::Store;
 use crate::StoreResult;
 
-use crate::domain::enums::{PlanStatusEnum, PlanTypeEnum};
 use crate::domain::{
     FullPlan, FullPlanNew, OrderByRequest, PaginatedVec, PaginationRequest, Plan,
-    PlanAndVersionPatch, PlanForList, PlanPatch, PlanVersion, PlanVersionLatest, PlanVersionNew,
-    PlanWithVersion, PriceComponent, PriceComponentNew, TrialPatch,
+    PlanAndVersionPatch, PlanFilters, PlanForList, PlanPatch, PlanVersion, PlanVersionLatest,
+    PlanVersionNew, PlanWithVersion, PriceComponent, PriceComponentNew, TrialPatch,
 };
 use common_eventbus::Event;
 use diesel_async::scoped_futures::ScopedFutureExt;
@@ -49,10 +48,8 @@ pub trait PlansInterface {
     async fn list_plans(
         &self,
         auth_tenant_id: Uuid,
-        search: Option<String>,
         product_family_external_id: Option<String>,
-        filter_status: Option<PlanStatusEnum>,
-        filter_type: Option<PlanTypeEnum>,
+        filters: PlanFilters,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<PlanForList>>;
@@ -299,10 +296,8 @@ impl PlansInterface for Store {
     async fn list_plans(
         &self,
         auth_tenant_id: Uuid,
-        search: Option<String>,
         product_family_external_id: Option<String>,
-        filter_status: Option<PlanStatusEnum>,
-        filter_type: Option<PlanTypeEnum>,
+        filters: PlanFilters,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<PlanForList>> {
@@ -311,10 +306,8 @@ impl PlansInterface for Store {
         let rows = PlanRowForList::list(
             &mut conn,
             auth_tenant_id,
-            search,
             product_family_external_id,
-            filter_status.map(|v| v.into()),
-            filter_type.map(|v| v.into()),
+            filters.into(),
             pagination.into(),
             order_by.into(),
         )

--- a/modules/meteroid/crates/meteroid-store/src/repositories/plans.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/plans.rs
@@ -1,16 +1,18 @@
 use crate::store::Store;
 use crate::StoreResult;
 
+use crate::domain::enums::{PlanStatusEnum, PlanTypeEnum};
 use crate::domain::{
     FullPlan, FullPlanNew, OrderByRequest, PaginatedVec, PaginationRequest, Plan,
     PlanAndVersionPatch, PlanForList, PlanPatch, PlanVersion, PlanVersionLatest, PlanVersionNew,
-    PlanWithVersion, PriceComponent, PriceComponentNew,
+    PlanWithVersion, PriceComponent, PriceComponentNew, TrialPatch,
 };
 use common_eventbus::Event;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_async::AsyncConnection;
 use diesel_models::plan_versions::{
     PlanVersionRow, PlanVersionRowLatest, PlanVersionRowNew, PlanVersionRowPatch,
+    PlanVersionTrialRowPatch,
 };
 use diesel_models::plans::{PlanRow, PlanRowForList, PlanRowNew, PlanRowPatch};
 use diesel_models::price_components::PriceComponentRow;
@@ -24,11 +26,18 @@ use crate::errors::StoreError;
 #[async_trait::async_trait]
 pub trait PlansInterface {
     async fn insert_plan(&self, plan: FullPlanNew) -> StoreResult<FullPlan>;
+
     async fn get_plan_by_external_id(
         &self,
         external_id: &str,
         auth_tenant_id: Uuid,
-    ) -> StoreResult<FullPlan>;
+    ) -> StoreResult<PlanWithVersion>;
+
+    async fn get_plan_by_id(
+        &self,
+        plan_id: Uuid,
+        auth_tenant_id: Uuid,
+    ) -> StoreResult<PlanWithVersion>;
 
     async fn find_plan_by_external_id_and_status(
         &self,
@@ -42,9 +51,12 @@ pub trait PlansInterface {
         auth_tenant_id: Uuid,
         search: Option<String>,
         product_family_external_id: Option<String>,
+        filter_status: Option<PlanStatusEnum>,
+        filter_type: Option<PlanTypeEnum>,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<PlanForList>>;
+
     async fn list_latest_published_plan_versions(
         &self,
         auth_tenant_id: Uuid,
@@ -96,6 +108,8 @@ pub trait PlansInterface {
     ) -> StoreResult<PlanWithVersion>;
 
     async fn patch_draft_plan(&self, patch: PlanAndVersionPatch) -> StoreResult<PlanWithVersion>;
+
+    async fn patch_trial(&self, patch: TrialPatch) -> StoreResult<PlanWithVersion>;
 }
 
 #[async_trait::async_trait]
@@ -196,7 +210,7 @@ impl PlansInterface for Store {
         &self,
         external_id: &str,
         auth_tenant_id: Uuid,
-    ) -> StoreResult<FullPlan> {
+    ) -> StoreResult<PlanWithVersion> {
         let mut conn = self.get_conn().await?;
 
         let plan: Plan =
@@ -211,19 +225,27 @@ impl PlansInterface for Store {
                 .map(Into::into)
                 .map_err(|err| StoreError::DatabaseError(err.error))?;
 
-        let price_components: Vec<PriceComponent> =
-            PriceComponentRow::list_by_plan_version_id(&mut conn, auth_tenant_id, version.id)
-                .await
-                .map_err(|err| StoreError::DatabaseError(err.error))?
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<Vec<_>, _>>()?;
+        Ok(PlanWithVersion { plan, version })
+    }
+    async fn get_plan_by_id(
+        &self,
+        plan_id: Uuid,
+        auth_tenant_id: Uuid,
+    ) -> StoreResult<PlanWithVersion> {
+        let mut conn = self.get_conn().await?;
 
-        Ok(FullPlan {
-            plan,
-            version,
-            price_components,
-        })
+        let plan: Plan = PlanRow::get_by_id_and_tenant_id(&mut conn, plan_id, auth_tenant_id)
+            .await
+            .map(Into::into)
+            .map_err(|err| StoreError::DatabaseError(err.error))?;
+
+        let version: PlanVersion =
+            PlanVersionRow::get_latest_by_plan_id_and_tenant_id(&mut conn, plan.id, auth_tenant_id)
+                .await
+                .map(Into::into)
+                .map_err(|err| StoreError::DatabaseError(err.error))?;
+
+        Ok(PlanWithVersion { plan, version })
     }
 
     async fn find_plan_by_external_id_and_status(
@@ -279,6 +301,8 @@ impl PlansInterface for Store {
         auth_tenant_id: Uuid,
         search: Option<String>,
         product_family_external_id: Option<String>,
+        filter_status: Option<PlanStatusEnum>,
+        filter_type: Option<PlanTypeEnum>,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<PlanForList>> {
@@ -289,6 +313,8 @@ impl PlansInterface for Store {
             auth_tenant_id,
             search,
             product_family_external_id,
+            filter_status.map(|v| v.into()),
+            filter_type.map(|v| v.into()),
             pagination.into(),
             order_by.into(),
         )
@@ -382,7 +408,10 @@ impl PlansInterface for Store {
                     plan_id: original.plan_id,
                     version: original.version + 1,
                     trial_duration_days: original.trial_duration_days,
-                    trial_fallback_plan_id: original.trial_fallback_plan_id,
+                    downgrade_plan_id: original.downgrade_plan_id,
+                    trialing_plan_id: original.trialing_plan_id,
+                    action_after_trial: original.action_after_trial,
+                    trial_is_free: original.trial_is_free,
                     tenant_id: original.tenant_id,
                     period_start_day: original.period_start_day,
                     net_terms: original.net_terms,
@@ -563,6 +592,50 @@ impl PlansInterface for Store {
 
                     patch_plan
                         .update(conn)
+                        .await
+                        .map_err(Into::<Report<StoreError>>::into)?;
+
+                    Ok(patched_version)
+                }
+                .scope_boxed()
+            })
+            .await?;
+
+        PlanRow::get_with_version(&mut conn, version.id, version.tenant_id)
+            .await
+            .map_err(Into::into)
+            .map(Into::into)
+    }
+
+    async fn patch_trial(&self, patch: TrialPatch) -> StoreResult<PlanWithVersion> {
+        let mut conn = self.get_conn().await?;
+
+        let version = self
+            .transaction(|conn| {
+                async move {
+                    let patch: PlanVersionTrialRowPatch = match patch.trial {
+                        None => PlanVersionTrialRowPatch {
+                            id: patch.plan_version_id,
+                            tenant_id: patch.tenant_id,
+                            trialing_plan_id: Some(None),
+                            action_after_trial: Some(None),
+                            trial_is_free: Some(false),
+                            trial_duration_days: Some(None),
+                            downgrade_plan_id: Some(None),
+                        },
+                        Some(trial) => PlanVersionTrialRowPatch {
+                            id: patch.plan_version_id,
+                            tenant_id: patch.tenant_id,
+                            trialing_plan_id: Some(trial.trialing_plan_id),
+                            action_after_trial: Some(trial.action_after_trial.map(Into::into)),
+                            trial_is_free: Some(trial.require_pre_authorization),
+                            trial_duration_days: Some(Some(trial.duration_days as i32)),
+                            downgrade_plan_id: Some(trial.downgrade_plan_id),
+                        },
+                    };
+
+                    let patched_version = patch
+                        .update_trial(conn)
                         .await
                         .map_err(Into::<Report<StoreError>>::into)?;
 

--- a/modules/meteroid/migrations/diesel/2024-10-01-084201_plan_trials/down.sql
+++ b/modules/meteroid/migrations/diesel/2024-10-01-084201_plan_trials/down.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "plan_version"
+  RENAME COLUMN "downgrade_plan_id" TO "trial_fallback_plan_id";
+
+ALTER TABLE "plan_version"
+  DROP COLUMN "trialing_plan_id",
+  DROP COLUMN "action_after_trial",
+  DROP COLUMN "trial_is_free"
+;
+
+DROP TYPE "ActionAfterTrialEnum";
+
+
+ALTER TABLE "plan_version"
+  ADD CONSTRAINT "plan_version_check" CHECK (((trial_duration_days IS NULL) AND (trial_fallback_plan_id IS NULL)) OR
+                                             ((trial_duration_days IS NOT NULL) AND
+                                              (trial_fallback_plan_id IS NOT NULL)));

--- a/modules/meteroid/migrations/diesel/2024-10-01-084201_plan_trials/up.sql
+++ b/modules/meteroid/migrations/diesel/2024-10-01-084201_plan_trials/up.sql
@@ -1,0 +1,13 @@
+CREATE TYPE "ActionAfterTrialEnum" AS ENUM ('BLOCK', 'CHARGE', 'DOWNGRADE');
+
+ALTER TABLE "plan_version"
+  RENAME COLUMN "trial_fallback_plan_id" TO "downgrade_plan_id";
+
+ALTER TABLE "plan_version"
+  ADD COLUMN "trialing_plan_id"   UUID REFERENCES "plan" ("id"),
+  ADD COLUMN "action_after_trial" "ActionAfterTrialEnum" NULL,
+  ADD COLUMN "trial_is_free"      BOOLEAN                NOT NULL DEFAULT TRUE;
+;
+
+ALTER TABLE "plan_version"
+  DROP CONSTRAINT "plan_version_check";

--- a/modules/meteroid/proto/api/plans/v1/models.proto
+++ b/modules/meteroid/proto/api/plans/v1/models.proto
@@ -55,7 +55,7 @@ message PlanBillingConfiguration {
 message TrialConfig {
   uint32 duration_days = 1;
   ActionAfterTrial action_after_trial = 2;
-  // if true, nothing will be charged. If true, the normal plan price is charged from the start, no matter the plan that this trial gives access to.
+  // if true, nothing will be charged. If false, the normal plan price is charged from the start, no matter the plan that this trial gives access to.
   bool trial_is_free = 3;
   // what plan is applied after the trial completes and before any payment
   optional string downgrade_plan_id = 4;

--- a/modules/meteroid/proto/api/plans/v1/models.proto
+++ b/modules/meteroid/proto/api/plans/v1/models.proto
@@ -11,11 +11,19 @@ enum PlanStatus {
   ARCHIVED = 3;
 }
 
+message PlanStatusFilter {
+  PlanStatus plan_status = 1;
+}
+
 enum PlanType {
   STANDARD = 0;
   FREE = 1;
   CUSTOM = 2;
   // template 3 ?
+}
+
+message PlanTypeFilter {
+  PlanType plan_type = 1;
 }
 
 message PlanBillingConfiguration {
@@ -44,11 +52,25 @@ message PlanBillingConfiguration {
   message Forever {}
 }
 
-// TODO allow more complexity, ex: via full Adjustment view (included units, credits, maximums/limits, discounts for some lines ,etc)
-// TODO in addition to fallback plan, maybe we want a "trial plan" or "use_trial_from_plan_id", aka a unique "entreprise_trial" no matter the selected plan, that then fallbacks on the current plan
 message TrialConfig {
-  uint32 duration_in_days = 1;
-  string fallback_plan_id = 2; // TODO only if no credit card added
+  uint32 duration_days = 1;
+  ActionAfterTrial action_after_trial = 2;
+  // if true, nothing will be charged. If true, the normal plan price is charged from the start, no matter the plan that this trial gives access to.
+  bool trial_is_free = 3;
+  // what plan is applied after the trial completes and before any payment
+  optional string downgrade_plan_id = 4;
+  // what plan is applied during the trial (ex: Enterprise for X days after paying Pro plan). None for current plan
+  optional string trialing_plan_id = 5;
+
+  // advanced options :
+  //  optional bool requires_pre_authorization = 6;
+  // usage_credits, custom trial limits, etc
+
+  enum ActionAfterTrial {
+    BLOCK = 0;
+    CHARGE = 1;
+    DOWNGRADE = 2;
+  }
 }
 
 message PlanVersion {
@@ -73,13 +95,12 @@ message ListSubscribablePlanVersion {
   string plan_name = 3;
   int32 version = 4;
   string created_by = 5;
-  optional int32 trial_duration_days = 6;
-  optional string trial_fallback_plan_id = 7;
   optional int32 period_start_day = 8;
   int32 net_terms = 9;
   string currency = 10;
   string product_family_id = 11;
   string product_family_name = 12;
+  TrialConfig trial_config = 13;
 }
 
 message Metadata {

--- a/modules/meteroid/proto/api/plans/v1/plans.proto
+++ b/modules/meteroid/proto/api/plans/v1/plans.proto
@@ -40,6 +40,8 @@ message ListPlansRequest {
   SortBy sort_by = 2;
   optional string search = 3;
   meteroid.common.v1.Pagination pagination = 4;
+  PlanTypeFilter plan_type_filter = 5;
+  PlanStatusFilter plan_status_filter = 6;
 }
 
 message ListPlansResponse {
@@ -68,8 +70,7 @@ message ListPlanVersionByIdResponse {
 }
 
 // Request and response messages for ListSubscribablePlansVersions RPC
-message ListSubscribablePlanVersionRequest {
-}
+message ListSubscribablePlanVersionRequest {}
 
 message ListSubscribablePlanVersionResponse {
   repeated ListSubscribablePlanVersion plan_versions = 1;
@@ -155,13 +156,31 @@ message GetPlanParametersResponse {
   repeated PlanParameter parameters = 1;
 }
 
-// Response message for all RPCs returning EmptyResponse
-message EmptyResponse {
+message UpdatePlanTrialRequest {
+  string plan_id = 1;
+  string plan_version_id = 2;
+  TrialConfig trial = 3;
 }
+
+message UpdatePlanTrialResponse {
+  PlanOverview plan_overview = 1;
+}
+
+message GetPlanByIdRequest {
+  string plan_id = 1;
+}
+
+message GetPlanByIdResponse {
+  PlanDetails plan_details = 1;
+}
+
+// Response message for all RPCs returning EmptyResponse
+message EmptyResponse {}
 
 service PlansService {
   rpc CreateDraftPlan(CreateDraftPlanRequest) returns (CreateDraftPlanResponse) {}
   rpc GetPlanByExternalId(GetPlanByExternalIdRequest) returns (GetPlanByExternalIdResponse) {}
+  rpc GetPlanById(GetPlanByIdRequest) returns (GetPlanByIdResponse) {}
   rpc ListPlans(ListPlansRequest) returns (ListPlansResponse) {}
 
   rpc GetPlanVersionById(GetPlanVersionByIdRequest) returns (GetPlanVersionByIdResponse) {}
@@ -176,6 +195,8 @@ service PlansService {
   rpc UpdateDraftPlanOverview(UpdateDraftPlanOverviewRequest) returns (UpdateDraftPlanOverviewResponse) {}
   rpc UpdatePublishedPlanOverview(UpdatePublishedPlanOverviewRequest) returns (UpdatePublishedPlanOverviewResponse) {}
   rpc GetPlanOverviewByExternalId(GetPlanOverviewByExternalIdRequest) returns (GetPlanOverviewByExternalIdResponse) {}
+
+  rpc UpdatePlanTrial(UpdatePlanTrialRequest) returns (UpdatePlanTrialResponse) {}
 
   rpc GetPlanParameters(GetPlanParametersRequest) returns (GetPlanParametersResponse) {}
 }

--- a/modules/meteroid/src/api/plans/service.rs
+++ b/modules/meteroid/src/api/plans/service.rs
@@ -1,4 +1,5 @@
 use tonic::{Request, Response, Status};
+use uuid::Uuid;
 
 use common_grpc::middleware::server::auth::RequestExt;
 use meteroid_grpc::meteroid::api::plans::v1::{
@@ -6,12 +7,13 @@ use meteroid_grpc::meteroid::api::plans::v1::{
     CopyVersionToDraftResponse, CreateDraftPlanRequest, CreateDraftPlanResponse,
     DiscardDraftVersionRequest, DiscardDraftVersionResponse, GetLastPublishedPlanVersionRequest,
     GetLastPublishedPlanVersionResponse, GetPlanByExternalIdRequest, GetPlanByExternalIdResponse,
-    GetPlanOverviewByExternalIdRequest, GetPlanOverviewByExternalIdResponse,
-    GetPlanParametersRequest, GetPlanParametersResponse, GetPlanVersionByIdRequest,
-    GetPlanVersionByIdResponse, ListPlanVersionByIdRequest, ListPlanVersionByIdResponse,
-    ListPlansRequest, ListPlansResponse, ListSubscribablePlanVersionRequest,
-    ListSubscribablePlanVersionResponse, PublishPlanVersionRequest, PublishPlanVersionResponse,
-    UpdateDraftPlanOverviewRequest, UpdateDraftPlanOverviewResponse,
+    GetPlanByIdRequest, GetPlanByIdResponse, GetPlanOverviewByExternalIdRequest,
+    GetPlanOverviewByExternalIdResponse, GetPlanParametersRequest, GetPlanParametersResponse,
+    GetPlanVersionByIdRequest, GetPlanVersionByIdResponse, ListPlanVersionByIdRequest,
+    ListPlanVersionByIdResponse, ListPlansRequest, ListPlansResponse,
+    ListSubscribablePlanVersionRequest, ListSubscribablePlanVersionResponse,
+    PublishPlanVersionRequest, PublishPlanVersionResponse, UpdateDraftPlanOverviewRequest,
+    UpdateDraftPlanOverviewResponse, UpdatePlanTrialRequest, UpdatePlanTrialResponse,
     UpdatePublishedPlanOverviewRequest, UpdatePublishedPlanOverviewResponse,
 };
 use meteroid_grpc::meteroid::api::shared::v1::BillingPeriod;
@@ -20,13 +22,17 @@ use crate::api::plans::error::PlanApiError;
 
 use crate::api::domain_mapping::billing_period;
 use crate::api::plans::mapping::plans::{
-    ListPlanVersionWrapper, ListPlanWrapper, ListSubscribablePlanVersionWrapper,
-    PlanDetailsWrapper, PlanOverviewWrapper, PlanTypeWrapper, PlanVersionWrapper,
+    ActionAfterTrialWrapper, ListPlanVersionWrapper, ListPlanWrapper,
+    ListSubscribablePlanVersionWrapper, PlanDetailsWrapper, PlanOverviewWrapper, PlanStatusWrapper,
+    PlanTypeWrapper, PlanVersionWrapper,
 };
+use crate::api::shared::conversions::{FromProtoOpt, ProtoConv};
 use crate::api::utils::PaginationExt;
 use crate::{api::utils::parse_uuid, parse_uuid};
 use meteroid_store::domain;
-use meteroid_store::domain::{OrderByRequest, PlanAndVersionPatch, PlanPatch, PlanVersionPatch};
+use meteroid_store::domain::{
+    OrderByRequest, PlanAndVersionPatch, PlanPatch, PlanVersionPatch, TrialPatch,
+};
 use meteroid_store::repositories::PlansInterface;
 
 use super::PlanServiceComponents;
@@ -58,8 +64,7 @@ impl PlansService for PlanServiceComponents {
             },
             version: domain::PlanVersionNewInternal {
                 is_draft_version: true,
-                trial_duration_days: None,
-                trial_fallback_plan_id: None,
+                trial: None,
                 period_start_day: None,
                 net_terms: 0,
                 currency: None,
@@ -124,12 +129,21 @@ impl PlansService for PlanServiceComponents {
             Err(_) => OrderByRequest::DateDesc,
         };
 
+        let filter_status = req
+            .plan_status_filter
+            .map(|filter| PlanStatusWrapper(filter.plan_status()).into());
+        let filter_type = req
+            .plan_type_filter
+            .map(|filter| PlanTypeWrapper(filter.plan_type()).into());
+
         let res = self
             .store
             .list_plans(
                 tenant_id,
                 req.search,
                 req.product_family_external_id,
+                filter_status,
+                filter_type,
                 pagination_req,
                 order_by,
             )
@@ -405,11 +419,72 @@ impl PlansService for PlanServiceComponents {
         Ok(Response::new(response))
     }
 
+    #[tracing::instrument(skip_all)]
     async fn get_plan_parameters(
         &self,
         _request: Request<GetPlanParametersRequest>,
     ) -> Result<Response<GetPlanParametersResponse>, Status> {
         todo!()
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn update_plan_trial(
+        &self,
+        request: Request<UpdatePlanTrialRequest>,
+    ) -> Result<Response<UpdatePlanTrialResponse>, Status> {
+        let tenant_id = request.tenant()?;
+        let req = request.into_inner();
+
+        let plan_version_id = parse_uuid!(&req.plan_version_id)?;
+
+        let res = self
+            .store
+            .patch_trial(TrialPatch {
+                tenant_id,
+                plan_version_id,
+                trial: req
+                    .trial
+                    .map(|t| {
+                        Ok::<domain::PlanTrial, Status>(domain::PlanTrial {
+                            action_after_trial: Some(
+                                ActionAfterTrialWrapper(t.action_after_trial()).into(),
+                            ),
+                            duration_days: t.duration_days,
+                            trialing_plan_id: Uuid::from_proto_opt(t.trialing_plan_id)?,
+                            downgrade_plan_id: Uuid::from_proto_opt(t.downgrade_plan_id)?,
+                            require_pre_authorization: t.trial_is_free,
+                        })
+                    })
+                    .transpose()?,
+            })
+            .await
+            .map_err(Into::<PlanApiError>::into)
+            .map(|x| PlanOverviewWrapper::from(x).0)?;
+
+        Ok(Response::new(UpdatePlanTrialResponse {
+            plan_overview: Some(res),
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn get_plan_by_id(
+        &self,
+        request: Request<GetPlanByIdRequest>,
+    ) -> Result<Response<GetPlanByIdResponse>, Status> {
+        let tenant_id = request.tenant()?;
+
+        let req = request.into_inner();
+
+        let plan_details = self
+            .store
+            .get_plan_by_id(Uuid::from_proto(req.plan_id)?, tenant_id)
+            .await
+            .map(|x| PlanDetailsWrapper::from(x).0)
+            .map_err(Into::<PlanApiError>::into)?;
+
+        Ok(Response::new(GetPlanByIdResponse {
+            plan_details: Some(plan_details),
+        }))
     }
 
     //

--- a/modules/meteroid/src/api/plans/service.rs
+++ b/modules/meteroid/src/api/plans/service.rs
@@ -31,7 +31,7 @@ use crate::api::utils::PaginationExt;
 use crate::{api::utils::parse_uuid, parse_uuid};
 use meteroid_store::domain;
 use meteroid_store::domain::{
-    OrderByRequest, PlanAndVersionPatch, PlanPatch, PlanVersionPatch, TrialPatch,
+    OrderByRequest, PlanAndVersionPatch, PlanFilters, PlanPatch, PlanVersionPatch, TrialPatch,
 };
 use meteroid_store::repositories::PlansInterface;
 
@@ -140,10 +140,12 @@ impl PlansService for PlanServiceComponents {
             .store
             .list_plans(
                 tenant_id,
-                req.search,
                 req.product_family_external_id,
-                filter_status,
-                filter_type,
+                PlanFilters {
+                    search: req.search,
+                    filter_status,
+                    filter_type,
+                },
                 pagination_req,
                 order_by,
             )

--- a/modules/meteroid/src/api/shared.rs
+++ b/modules/meteroid/src/api/shared.rs
@@ -65,8 +65,6 @@ pub mod mapping {
 pub mod conversions {
     use std::str::FromStr;
 
-    //  custom error instead of status ?
-
     pub trait ProtoConv<T> {
         fn as_proto(&self) -> T;
         fn from_proto(proto: T) -> Result<Self, tonic::Status>

--- a/modules/meteroid/src/bin/seeder.rs
+++ b/modules/meteroid/src/bin/seeder.rs
@@ -87,8 +87,7 @@ async fn main() -> error_stack::Result<(), SeederError> {
                 description: None,
                 plan_type: PlanTypeEnum::Free,
                 version_details: domain::PlanVersion {
-                    trial_duration_days: None,
-                    trial_fallback_plan_id: None,
+                    trial: None,
                     period_start_day: None,
                     currency: tenant_currency.clone(),
                     billing_cycles: None,
@@ -105,8 +104,7 @@ async fn main() -> error_stack::Result<(), SeederError> {
                 description: None,
                 plan_type: PlanTypeEnum::Standard,
                 version_details: domain::PlanVersion {
-                    trial_duration_days: None,
-                    trial_fallback_plan_id: None,
+                    trial: None,
                     period_start_day: None,
                     currency: tenant_currency.clone(),
                     billing_cycles: None,
@@ -138,8 +136,7 @@ async fn main() -> error_stack::Result<(), SeederError> {
                 description: None,
                 plan_type: PlanTypeEnum::Standard,
                 version_details: domain::PlanVersion {
-                    trial_duration_days: None,
-                    trial_fallback_plan_id: None,
+                    trial: None,
                     period_start_day: None,
                     currency: tenant_currency.clone(),
                     billing_cycles: None,

--- a/modules/meteroid/src/seeder/domain.rs
+++ b/modules/meteroid/src/seeder/domain.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 use meteroid_store::domain::enums::{BillingPeriodEnum, PlanTypeEnum};
-use uuid::Uuid;
+use meteroid_store::domain::PlanTrial;
 
 // pub enum PlanType {
 //     Free,
@@ -20,13 +20,12 @@ pub struct Tenant {
 
 #[derive(Clone)]
 pub struct PlanVersion {
-    pub trial_duration_days: Option<i32>,
-    pub trial_fallback_plan_id: Option<Uuid>,
     pub period_start_day: Option<i16>,
     pub currency: String,
     pub billing_cycles: Option<i32>,
     pub billing_periods: Vec<BillingPeriodEnum>,
     pub net_terms: i32,
+    pub trial: Option<PlanTrial>,
 }
 
 // #[derive(Clone)]

--- a/modules/meteroid/src/seeder/runner.rs
+++ b/modules/meteroid/src/seeder/runner.rs
@@ -117,8 +117,7 @@ pub async fn run(
                 },
                 version: store_domain::PlanVersionNewInternal {
                     is_draft_version: false,
-                    trial_duration_days: plan.version_details.trial_duration_days,
-                    trial_fallback_plan_id: plan.version_details.trial_fallback_plan_id,
+                    trial: plan.version_details.trial.clone(),
                     period_start_day: plan.version_details.period_start_day,
                     net_terms: plan.version_details.net_terms,
                     currency: Some(plan.version_details.currency),

--- a/modules/meteroid/tests/integration/test_plan.rs
+++ b/modules/meteroid/tests/integration/test_plan.rs
@@ -103,6 +103,8 @@ async fn test_plans_basic() {
             sort_by: 0,
             search: None,
             pagination: None,
+            plan_type_filter: None,
+            plan_status_filter: None,
         })
         .await
         .unwrap()

--- a/modules/web/packages/ui/src/components/form/input-form-field.tsx
+++ b/modules/web/packages/ui/src/components/form/input-form-field.tsx
@@ -1,6 +1,6 @@
 import { Control, FieldPath, FieldValues, PathValue, UseControllerProps } from 'react-hook-form'
 
-import { Input } from '..'
+import { Input, InputProps } from '..'
 
 import { GenericFormField, GenericFormFieldVariantProps } from './generic-form-field'
 import { destructuredFormProps } from './utils'
@@ -11,7 +11,7 @@ interface Transformer<T> {
 }
 
 interface InputFieldProps<TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'defaultValue' | 'name'>,
+  extends Omit<InputProps, 'defaultValue' | 'name'>,
     UseControllerProps<TFieldValues, TName> {
   label?: string
   description?: string

--- a/modules/web/packages/ui/src/components/ui/input.tsx
+++ b/modules/web/packages/ui/src/components/ui/input.tsx
@@ -2,20 +2,34 @@ import * as React from 'react'
 
 import { cn } from '@ui/lib'
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  rightText?: string
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
-    return (
+    const _Input = () => (
       <input
         type={type}
         className={cn(
           'flex h-9 w-full rounded-md border border-border bg-input px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:bg-muted',
+          props.rightText && 'rounded-r-none',
           className
         )}
         ref={ref}
         {...props}
       />
+    )
+
+    return props.rightText ? (
+      <div className="flex">
+        <_Input />
+        <div className="border border-border border-l-0 rounded-md rounded-l-none self-end h-9 text-sm px-2 content-center bg-muted text-muted-foreground">
+          {props.rightText}
+        </div>
+      </div>
+    ) : (
+      <_Input />
     )
   }
 )

--- a/modules/web/web-app/buf.gen.yaml
+++ b/modules/web/web-app/buf.gen.yaml
@@ -1,9 +1,11 @@
 version: v1
 types:
   include:
+    - meteroid.api.addons.v1.AddOnsService
     - meteroid.api.apitokens.v1.ApiTokensService
     - meteroid.api.billablemetrics.v1.BillableMetricsService
     - meteroid.api.customers.v1.CustomersService
+    - meteroid.api.coupons.v1.CouponsService
     - meteroid.api.instance.v1.InstanceService
     - meteroid.api.invoices.v1.InvoicesService
     - meteroid.api.plans.v1.PlansService

--- a/modules/web/web-app/components/form/PriceInput.tsx
+++ b/modules/web/web-app/components/form/PriceInput.tsx
@@ -1,5 +1,5 @@
-import { InputProps, useFormField, cn } from '@md/ui'
-import { useEffect, useMemo, useState, forwardRef } from 'react'
+import { InputProps, cn, useFormField } from '@md/ui'
+import { forwardRef, useEffect, useMemo, useState } from 'react'
 import { Control, FieldValues, UseControllerProps, useController } from 'react-hook-form'
 
 type BaseProps = {
@@ -36,7 +36,7 @@ const PriceInput = <T extends FieldValues>({
   precision = 2,
   ...props
 }: Props<T>) => {
-  const { field, fieldState } = useController({ ...props })
+  const { field, fieldState } = useController(props)
 
   const [inputValue, setInputValue] = useState('')
 

--- a/modules/web/web-app/components/layouts/shared/PageSection.tsx
+++ b/modules/web/web-app/components/layouts/shared/PageSection.tsx
@@ -9,7 +9,7 @@ interface PageSectionProps {
 }
 export const PageSection: React.FC<PageSectionProps> = ({ children, header, className = '' }) => {
   return (
-    <div className={`relative pb-4 ${className}`}>
+    <div className={`relative pb-4 ml-[1px] ${className} `}>
       {header && (
         <div className="pb-3 border-b border-muted-foreground space-y-1">
           <div className="flex justify-between items-end">
@@ -21,7 +21,7 @@ export const PageSection: React.FC<PageSectionProps> = ({ children, header, clas
           )}
         </div>
       )}
-      <div className="py-6">{children}</div>
+      <div className="py-6  ">{children}</div>
     </div>
   )
 }

--- a/modules/web/web-app/components/table/ExpandableTable.tsx
+++ b/modules/web/web-app/components/table/ExpandableTable.tsx
@@ -1,4 +1,4 @@
-import { TableRow, TableCell } from '@md/ui'
+import { TableCell, TableRow } from '@md/ui'
 import {
   ColumnDef,
   OnChangeFn,
@@ -92,9 +92,7 @@ export const expandColumn: ColumnDef<unknown> = {
       <button
         {...{
           onClick: () => {
-            console.log('BEFORE', row.getIsExpanded())
             row.toggleExpanded()
-            console.log('AFTER', row.getIsExpanded())
           },
           style: { cursor: 'pointer' },
         }}

--- a/modules/web/web-app/features/billing/plans/PlansTable.tsx
+++ b/modules/web/web-app/features/billing/plans/PlansTable.tsx
@@ -12,7 +12,7 @@ import { useTypedParams } from '@/utils/params'
 
 import type { FunctionComponent } from 'react'
 
-export const PlansTable: FunctionComponent = () => {
+export const PlansTable: FunctionComponent<{ search: string | undefined }> = ({ search }) => {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
     pageSize: 20,
@@ -27,6 +27,7 @@ export const PlansTable: FunctionComponent = () => {
       offset: pagination.pageIndex * pagination.pageSize,
     },
     sortBy: ListPlansRequest_SortBy.DATE_DESC,
+    search: search ? search : undefined,
   })
   const isLoading = plansQuery.isLoading
 

--- a/modules/web/web-app/features/billing/plans/pricecomponents/utils.ts
+++ b/modules/web/web-app/features/billing/plans/pricecomponents/utils.ts
@@ -1,6 +1,6 @@
 import { createConnectQueryKey, disableQuery, useMutation } from '@connectrpc/connect-query'
 import { useQueryClient } from '@tanstack/react-query'
-import { useSetAtom, atom, useAtomValue } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { nanoid } from 'nanoid'
 import { DeepPartial } from 'react-hook-form'
 import { match } from 'ts-pattern'
@@ -8,7 +8,7 @@ import { match } from 'ts-pattern'
 import { usePlan } from '@/features/billing/plans/hooks/usePlan'
 import { PriceComponent, PriceComponentType } from '@/features/billing/plans/types'
 import { useQuery } from '@/lib/connectrpc'
-import { mapBillingPeriodFromGrpc, BillingPeriod, mapBillingPeriod } from '@/lib/mapping'
+import { BillingPeriod, mapBillingPeriod, mapBillingPeriodFromGrpc } from '@/lib/mapping'
 import {
   getPlanOverviewByExternalId,
   updateDraftPlanOverview,

--- a/modules/web/web-app/features/billing/plans/trial/PlanTrial.tsx
+++ b/modules/web/web-app/features/billing/plans/trial/PlanTrial.tsx
@@ -1,0 +1,498 @@
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query'
+import {
+  Button,
+  Form,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@md/ui'
+import { useQueryClient } from '@tanstack/react-query'
+import { forwardRef, useState } from 'react'
+import { Controller } from 'react-hook-form'
+import { z } from 'zod'
+
+import { useIsDraftVersion } from '@/features/billing/plans/pricecomponents/utils'
+import { useZodForm } from '@/hooks/useZodForm'
+import { useQuery } from '@/lib/connectrpc'
+import { PlanType, TrialConfig, TrialConfig_ActionAfterTrial } from '@/rpc/api/plans/v1/models_pb'
+import {
+  getPlanByExternalId,
+  listPlans,
+  updatePlanTrial,
+} from '@/rpc/api/plans/v1/plans-PlansService_connectquery'
+import { ListPlansRequest_SortBy } from '@/rpc/api/plans/v1/plans_pb'
+
+interface TrialProps {
+  config?: TrialConfig
+  currentPlanId: string
+  currentPlanExternalId: string
+  currentPlanVersionId: string
+}
+
+const mapActionAfterTrial = (action?: TrialConfig_ActionAfterTrial) => {
+  switch (action) {
+    case TrialConfig_ActionAfterTrial.BLOCK:
+      return 'BLOCK'
+    case TrialConfig_ActionAfterTrial.CHARGE:
+      return 'CHARGE'
+    case TrialConfig_ActionAfterTrial.DOWNGRADE:
+      return 'DOWNGRADE'
+    default:
+      return 'BLOCK'
+  }
+}
+
+const actionAfterTrialToGrpc = (action?: 'BLOCK' | 'CHARGE' | 'DOWNGRADE') => {
+  switch (action) {
+    case 'BLOCK':
+      return TrialConfig_ActionAfterTrial.BLOCK
+    case 'CHARGE':
+      return TrialConfig_ActionAfterTrial.CHARGE
+    case 'DOWNGRADE':
+      return TrialConfig_ActionAfterTrial.DOWNGRADE
+    case undefined:
+      return TrialConfig_ActionAfterTrial.BLOCK
+  }
+}
+
+export const PlanTrial = ({
+  config,
+  currentPlanId,
+  currentPlanVersionId,
+  currentPlanExternalId,
+}: TrialProps) => {
+  const isDraft = useIsDraftVersion()
+  const [isEditing, setIsEditing] = useState(false)
+
+  if (isEditing) {
+    return (
+      <PlanTrialForm
+        config={config}
+        currentPlanId={currentPlanId}
+        currentPlanVersionId={currentPlanVersionId}
+        currentPlanExternalId={currentPlanExternalId}
+        cancel={() => setIsEditing(false)}
+        afterSubmit={() => setIsEditing(false)}
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-row gap-2 items-center text-sm ">
+      <PlanTrialReadonly config={config} currentPlanId={currentPlanId} />
+      {isDraft && (
+        <Button type="button" variant="link" onClick={() => setIsEditing(true)}>
+          Edit
+        </Button>
+      )}
+    </div>
+  )
+}
+
+const formSchema = z.object({
+  durationDays: z.number().int().optional(),
+  trialingPlanId: z.string().uuid().optional(),
+  trialType: z.enum(['free', 'paid']).optional(),
+  actionAfterTrial: z.enum(['BLOCK', 'CHARGE', 'DOWNGRADE']).optional(),
+  downgradePlanId: z.string().uuid().optional(),
+})
+
+interface TrialConfigSentenceProps {
+  config?: TrialConfig
+  currentPlanId: string
+  currentPlanVersionId: string
+  currentPlanExternalId: string
+  afterSubmit: () => void
+  cancel: () => void
+}
+export function PlanTrialForm({
+  config,
+  currentPlanId,
+  currentPlanVersionId,
+  currentPlanExternalId,
+  afterSubmit,
+  cancel,
+}: TrialConfigSentenceProps) {
+  console.log('config', config)
+  const methods = useZodForm({
+    schema: formSchema,
+    defaultValues: {
+      trialType: !config || config?.trialIsFree ? 'free' : 'paid',
+      durationDays: config?.durationDays ?? 0,
+      actionAfterTrial: mapActionAfterTrial(config?.actionAfterTrial),
+      downgradePlanId: config?.downgradePlanId,
+      trialingPlanId: config?.trialingPlanId,
+      //   requiresPreAuthorization: config?.requiresPreAuthorization ?? false,
+    },
+  })
+
+  const queryClient = useQueryClient()
+
+  const mutation = useMutation(updatePlanTrial, {
+    onSuccess: () => {
+      afterSubmit()
+      queryClient.invalidateQueries({
+        queryKey: createConnectQueryKey(getPlanByExternalId, { externalId: currentPlanExternalId }),
+      })
+    },
+  })
+
+  const plans = useQuery(listPlans, {
+    sortBy: ListPlansRequest_SortBy.NAME_ASC,
+    // TODO filter out custom plans. We need to support arrays in the filter
+    //   planTypeFilter
+  })
+
+  const data = methods.watch()
+
+  const plansOptions = (plans.data?.plans ?? []).map(plan => ({
+    value: plan.id,
+    name: plan.name,
+  }))
+
+  const nonFreePlansOptions = (
+    plans.data?.plans.filter(p => p.planType !== PlanType.FREE) ?? []
+  ).map(plan => ({
+    value: plan.id,
+    name: plan.name,
+  }))
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Form {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(data => {
+              const trialIsFree = !data.trialType || data.trialType === 'free'
+
+              const trial =
+                data?.durationDays && data.durationDays > 0
+                  ? {
+                      actionAfterTrial: actionAfterTrialToGrpc(data.actionAfterTrial),
+                      downgradePlanId:
+                        trialIsFree && data.actionAfterTrial === 'DOWNGRADE'
+                          ? data.downgradePlanId
+                          : undefined,
+                      trialingPlanId: data.trialingPlanId,
+                      durationDays: data.durationDays,
+                      trialIsFree,
+                      requiresPreAuthorization: false, // TODO
+                    }
+                  : undefined
+
+              return mutation.mutateAsync({
+                planId: currentPlanId,
+                planVersionId: currentPlanVersionId,
+                trial,
+              })
+            })}
+            className="space-y-4 text-sm"
+          >
+            {!data.durationDays || data.durationDays <= 0 ? (
+              <p className="text-sm">
+                No trial configured.
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={() =>
+                    methods.reset({
+                      durationDays: 14,
+                    })
+                  }
+                >
+                  Add trial
+                </Button>
+              </p>
+            ) : (
+              <p className="text-sm">
+                Your users will get{' '}
+                <Controller
+                  name="durationDays"
+                  control={methods.control}
+                  render={({ field }) => <EditableSpan {...field} type="number" />}
+                />{' '}
+                days of the{' '}
+                <Controller
+                  name="trialingPlanId"
+                  control={methods.control}
+                  render={({ field }) => (
+                    <EditableSpan
+                      {...field}
+                      options={nonFreePlansOptions}
+                      emptyMessage="current"
+                      quotes
+                    />
+                  )}
+                />{' '}
+                plan{' '}
+                {!data.trialingPlanId || data.trialingPlanId === currentPlanId ? (
+                  'for free'
+                ) : (
+                  <Controller
+                    name="trialType"
+                    control={methods.control}
+                    render={({ field }) => (
+                      <EditableSpan
+                        onChange={field.onChange}
+                        value={field.value}
+                        options={[
+                          { value: 'free', name: 'for free' },
+                          { value: 'paid', name: 'at the current plan price' },
+                        ]}
+                        emptyMessage="for free"
+                      />
+                    )}
+                  />
+                )}
+                , then be{' '}
+                {data.trialType === 'paid' ? (
+                  'downgraded to the current plan'
+                ) : (
+                  <>
+                    <Controller
+                      name="actionAfterTrial"
+                      control={methods.control}
+                      render={({ field }) => (
+                        <EditableSpan
+                          {...field}
+                          options={[
+                            { value: 'BLOCK', name: 'blocked' },
+                            { value: 'CHARGE', name: 'charged' },
+                            { value: 'DOWNGRADE', name: 'downgraded' },
+                          ]}
+                          emptyMessage="blocked"
+                        />
+                      )}
+                    />
+                    {data.actionAfterTrial === 'DOWNGRADE' && (
+                      <>
+                        {' '}
+                        to the{' '}
+                        <Controller
+                          name="downgradePlanId"
+                          control={methods.control}
+                          render={({ field }) => (
+                            <EditableSpan
+                              {...field}
+                              options={plansOptions}
+                              emptyMessage="current"
+                              quotes
+                            />
+                          )}
+                        />{' '}
+                        plan
+                      </>
+                    )}
+                  </>
+                )}
+                .
+                <Button
+                  type="button"
+                  variant="link"
+                  className="text-destructive"
+                  onClick={() =>
+                    methods.reset({
+                      durationDays: 0,
+                    })
+                  }
+                >
+                  Remove trial
+                </Button>
+              </p>
+            )}
+
+            {methods.formState.errors && (
+              <div className="text-[0.8rem] font-medium text-destructive">
+                {methods.formState.errors.durationDays && (
+                  <p>
+                    Invalid duration : {String(methods.formState.errors.trialingPlanId?.message)}
+                  </p>
+                )}
+                {methods.formState.errors.actionAfterTrial && (
+                  <p>
+                    Invalid action : {String(methods.formState.errors.actionAfterTrial?.message)}
+                  </p>
+                )}
+                {methods.formState.errors.downgradePlanId && (
+                  <p>
+                    Invalid downgrade plan :{' '}
+                    {String(methods.formState.errors.downgradePlanId?.message)}
+                  </p>
+                )}
+                {methods.formState.errors.trialingPlanId && (
+                  <p>
+                    Invalid trial plan : {String(methods.formState.errors.trialingPlanId?.message)}
+                  </p>
+                )}
+                {methods.formState.errors.trialType && (
+                  <p>Invalid trial type : {String(methods.formState.errors.trialType?.message)}</p>
+                )}
+                {methods.formState.errors.root && (
+                  <p>Error : {String(methods.formState.errors.root?.message)}</p>
+                )}
+              </div>
+            )}
+
+            <div>
+              <Button
+                type="button"
+                variant="link"
+                className="text-foreground px-0 mr-4"
+                onClick={cancel}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" variant="link" className="px-0">
+                Save
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
+    </div>
+  )
+}
+
+interface PlanTrialReadonlyProps {
+  config?: TrialConfig
+  currentPlanId: string
+}
+export function PlanTrialReadonly({ config, currentPlanId }: PlanTrialReadonlyProps) {
+  // TODO resolve plan names in server
+  const { data: plansData, isLoading } = useQuery(listPlans, {
+    sortBy: ListPlansRequest_SortBy.NAME_ASC,
+  })
+
+  const resolvePlanName = (id: string): string => {
+    if (isLoading) return 'loading'
+    const plan = plansData?.plans.find(p => p.id === id)
+    return plan?.name ?? 'unknown'
+  }
+
+  const isCurrentPlan = (planId?: string) => !planId || planId === currentPlanId
+
+  if (!config) {
+    return <p className="text-sm">No trial configured.</p>
+  }
+
+  const renderActionAfterTrial = () => {
+    const { actionAfterTrial, downgradePlanId } = config
+
+    switch (actionAfterTrial) {
+      case TrialConfig_ActionAfterTrial.DOWNGRADE:
+        return (
+          <>
+            <span className="font-bold">downgraded</span> to the{' '}
+            <span className="font-bold">
+              {isCurrentPlan(downgradePlanId) ? 'current' : resolvePlanName(downgradePlanId!)}
+            </span>{' '}
+            plan
+          </>
+        )
+      case TrialConfig_ActionAfterTrial.CHARGE:
+        return <span className="font-bold">charged</span>
+      default:
+        return <span className="font-bold">blocked</span>
+    }
+  }
+
+  const renderTrialDescription = () => {
+    const { durationDays, trialingPlanId, trialIsFree } = config
+
+    if (!durationDays || durationDays <= 0) {
+      return <p className="text-sm">No trial configured.</p>
+    }
+
+    const trialPlanName = isCurrentPlan(trialingPlanId)
+      ? 'current'
+      : resolvePlanName(trialingPlanId!)
+    const trialPriceDescription = trialIsFree ? 'for free' : 'at the current plan price'
+
+    return (
+      <p className="text-sm">
+        Your users will get <span className="font-bold">{durationDays}</span> days of the{' '}
+        <span className="font-bold">{trialPlanName}</span> plan {trialPriceDescription}, then be{' '}
+        {trialIsFree ? renderActionAfterTrial() : 'downgraded to the current plan'}.
+      </p>
+    )
+  }
+
+  return <div className="space-y-4">{renderTrialDescription()}</div>
+}
+
+interface EditableSpanProps {
+  value?: string | number
+  onChange: (newValue: string | number) => void
+  options?: { name: string; value: string; label?: string }[]
+  type?: 'text' | 'number'
+  emptyMessage?: string
+  quotes?: boolean
+}
+
+const EditableSpan = forwardRef(
+  (
+    { value, onChange, options, type = 'text', emptyMessage, quotes = false }: EditableSpanProps,
+    _ref
+  ) => {
+    const [isEditing, setIsEditing] = useState(false)
+
+    if (isEditing) {
+      if (options) {
+        return (
+          <Select
+            value={value as string}
+            onValueChange={newValue => {
+              onChange(newValue)
+              setIsEditing(false)
+            }}
+            defaultOpen
+            onOpenChange={open => !open && setIsEditing(false)}
+          >
+            <SelectTrigger className="w-[200px]  inline-flex" autoFocus>
+              <SelectValue
+                placeholder="Please select"
+                onBlur={() => setIsEditing(false)}
+                autoFocus
+              />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map(option => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.name || option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )
+      } else {
+        return (
+          <Input
+            type={type}
+            value={value}
+            className="w-[200px] inline-flex"
+            onChange={e =>
+              onChange(type === 'number' ? parseInt(e.target.value, 10) : e.target.value)
+            }
+            onBlur={() => setIsEditing(false)}
+            autoFocus
+            min={type === 'number' ? 0 : undefined}
+            max={type === 'number' ? 9999 : undefined}
+            step={type === 'number' ? 1 : undefined}
+          />
+        )
+      }
+    }
+
+    const msg = options ? options.find(o => o.value === value)?.name || value : value
+    return (
+      <span onClick={() => setIsEditing(true)} className="font-bold cursor-pointer underline">
+        {quotes && msg && <span>&quot;</span>}
+        {msg ?? emptyMessage}
+        {quotes && msg && <span>&quot;</span>}
+      </span>
+    )
+  }
+)

--- a/modules/web/web-app/features/productCatalog/addons/AddonCreatePanel.tsx
+++ b/modules/web/web-app/features/productCatalog/addons/AddonCreatePanel.tsx
@@ -1,0 +1,48 @@
+import { FunctionComponent } from 'react'
+
+// import { createAddOn, listAddOns } from '@/rpc/api/addons/v1/addons-AddOnsService_connectquery'
+
+// import { CatalogEditPanel } from '@/features/productCatalog/generic/CatalogEditPanel'
+// import { useZodForm } from '@/hooks/useZodForm'
+// import { schemas } from '@/lib/schemas'
+// import { useTypedParams } from '@/utils/params'
+// import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query'
+// import { useQueryClient } from '@tanstack/react-query'
+// import { useNavigate } from 'react-router-dom'
+
+export const AddonCreatePanel: FunctionComponent = () => {
+  return <>Not implemented</>
+  // const queryClient = useQueryClient()
+  // const navigate = useNavigate()
+  // const { familyExternalId } = useTypedParams<{ familyExternalId: string }>()
+
+  // const createAddonMut = useMutation(createAddOn, {
+  //   onSuccess: async () => {
+  //     await queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listAddOns) })
+  //   },
+  // })
+
+  // const createMethods = useZodForm({
+  //   schema: schemas.addons.createAddonSchema,
+  // })
+
+  // return (
+  //   <CatalogEditPanel
+  //     visible={true}
+  //     closePanel={() => navigate('..')}
+  //     title={'Create addon'}
+  //     methods={createMethods}
+  //     onSubmit={a =>
+  //       createAddonMut
+  //         .mutateAsync({
+  //           name: a.name,
+  //           // productFamilyExternalId: familyExternalId,
+  //           // fee TODO
+  //         })
+  //         .then(() => void 0)
+  //     }
+  //   >
+  //     test
+  //   </CatalogEditPanel>
+  // )
+}

--- a/modules/web/web-app/features/productCatalog/addons/AddonsPage.tsx
+++ b/modules/web/web-app/features/productCatalog/addons/AddonsPage.tsx
@@ -1,0 +1,55 @@
+// import { spaces } from '@md/foundation'
+// import { Flex } from '@ui/components/legacy'
+import { FunctionComponent } from 'react'
+
+// import { ProductItemsTable } from '@/features/productCatalog/items/ProductItemsTable'
+// import { useQuery } from '@/lib/connectrpc'
+// import { listAddOns } from '@/rpc/api/addons/v1/addons-AddOnsService_connectquery'
+// // import { ListAddOnRequest_SortBy } from '@/rpc/api/addons/v1/addons_pb'
+
+// import { AddonCreatePanel } from '@/features/productCatalog/addons/AddonCreatePanel'
+// import { CatalogHeader } from '@/features/productCatalog/generic/CatalogHeader'
+// import { useCatalogPageProps } from '@/features/productCatalog/generic/useCatalogPageProps'
+// import { useQueryClient } from '@tanstack/react-query'
+
+export const AddonsPage: FunctionComponent = () => {
+  return <>Not implemented</>
+
+  // const { baseQuery, paginationState, onSearch } = useCatalogPageProps()
+  // const [editPanelVisible, setEditPanelVisible] = useState(false)
+
+  // const query = useQuery(
+  //   listAddOns
+  // TODO
+  // baseQuery
+  //   ? {
+  //       ...baseQuery,
+  //       // sortBy: ListAddOnRequest_SortBy.DATE_DESC,
+  //     }
+  //   : disableQuery
+  // )
+
+  // const queryClient = useQueryClient()
+
+  // return (
+  //   <Flex direction="column" gap={spaces.space9}>
+  //     <CatalogHeader
+  //       heading="Addonsz"
+  //       newButtonText="New addonz"
+  //       setEditPanelVisible={setEditPanelVisible}
+  //       isLoading={query.isLoading}
+  //       refetch={query.refetch}
+  //       setSearch={onSearch}
+  //     />
+  //     <ProductItemsTable
+  //       data={query.data?.addOns ?? []}
+  //       pagination={paginationState[0]}
+  //       setPagination={paginationState[1]}
+  //       totalCount={/*TODO query.data?.paginationMeta?.total ??*/ 0}
+  //       isLoading={query.isLoading}
+  //     />
+  //     {/* TODO route-based, edit etc */}
+  //     <AddonCreatePanel />
+  //   </Flex>
+  // )
+}

--- a/modules/web/web-app/features/productCatalog/generic/CatalogEditPanel.tsx
+++ b/modules/web/web-app/features/productCatalog/generic/CatalogEditPanel.tsx
@@ -1,0 +1,97 @@
+import { spaces } from '@md/foundation'
+import {
+  Button,
+  Form,
+  Modal,
+  Separator,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from '@md/ui'
+import { Flex } from '@ui/components/legacy'
+import { useState } from 'react'
+import { z } from 'zod'
+
+import ConfirmationModal from '@/components/ConfirmationModal'
+import { Methods } from '@/hooks/useZodForm'
+
+export interface CatalogEditPanelProps<T extends z.ZodTypeAny> {
+  title: string
+  visible: boolean
+  methods: Methods<T>
+  closePanel: () => void
+  onSubmit: (values: z.infer<T>) => Promise<void>
+  children?: React.ReactNode
+}
+export function CatalogEditPanel<T extends z.ZodTypeAny>({
+  visible,
+  closePanel,
+  title,
+  methods,
+  onSubmit,
+  children,
+}: CatalogEditPanelProps<T>) {
+  const [isClosingPanel, setIsClosingPanel] = useState(false)
+
+  // TODO useConfirmationModal
+
+  const safeClosePanel = () => {
+    const isDirty = methods.formState.isDirty
+    if (isDirty) {
+      setIsClosingPanel(true)
+    } else {
+      methods.reset()
+      closePanel()
+    }
+  }
+
+  return (
+    <>
+      <Sheet key="TableEditor" open={visible} onOpenChange={safeClosePanel}>
+        <SheetContent size="small">
+          <Form {...methods}>
+            <form
+              onSubmit={methods.handleSubmit(async values => {
+                await onSubmit(values)
+                methods.reset()
+                closePanel()
+              })}
+            >
+              <SheetHeader className="pb-2">
+                <SheetTitle>{title}</SheetTitle>
+                <Separator />
+              </SheetHeader>
+              <Flex direction="column" gap={spaces.space7}>
+                {children}
+              </Flex>
+
+              <SheetFooter className="py-2">
+                <Button type="submit">Save</Button>
+              </SheetFooter>
+            </form>
+          </Form>
+        </SheetContent>
+      </Sheet>
+      <ConfirmationModal
+        visible={isClosingPanel}
+        header="Confirm to close"
+        buttonLabel="Confirm"
+        onSelectCancel={() => setIsClosingPanel(false)}
+        onSelectConfirm={() => {
+          setIsClosingPanel(false)
+          methods.reset()
+          closePanel()
+        }}
+      >
+        <Modal.Content>
+          <p className="py-4 text-sm text-muted-foreground">
+            There are unsaved changes. Are you sure you want to close the panel? Your changes will
+            be lost.
+          </p>
+        </Modal.Content>
+      </ConfirmationModal>
+    </>
+  )
+}

--- a/modules/web/web-app/features/productCatalog/generic/CatalogHeader.tsx
+++ b/modules/web/web-app/features/productCatalog/generic/CatalogHeader.tsx
@@ -2,36 +2,48 @@ import { spaces } from '@md/foundation'
 import { PlusIcon, SearchIcon } from '@md/icons'
 import { Button, InputWithIcon } from '@md/ui'
 import { Flex } from '@ui/components/legacy'
+import { RefreshCwIcon } from 'lucide-react'
 import { FunctionComponent } from 'react'
 
 import PageHeading from '@/components/PageHeading/PageHeading'
 
-interface PlansHeaderProps {
+interface CatalogHeaderProps {
+  heading: string
+  newButtonText: string
+  isLoading: boolean
+  refetch: () => void
   setEditPanelVisible: (visible: boolean) => void
-  setSearch: (value: string | undefined) => void
+  setSearch: (value: string) => void
 }
 
-export const PlansHeader: FunctionComponent<PlansHeaderProps> = ({
+export const CatalogHeader: FunctionComponent<CatalogHeaderProps> = ({
+  heading,
+  newButtonText,
+  isLoading,
+  refetch,
   setEditPanelVisible,
   setSearch,
 }) => {
   return (
     <Flex direction="column" gap={spaces.space9}>
       <Flex direction="row" align="center" justify="space-between">
-        <PageHeading>Plans</PageHeading>
+        <PageHeading>{heading}</PageHeading>
         <Flex direction="row" gap={spaces.space4}>
-          <Button variant="primary" hasIcon onClick={() => setEditPanelVisible(true)} size="sm">
-            <PlusIcon size={10} /> New plan
+          <Button hasIcon variant="primary" onClick={() => setEditPanelVisible(true)} size="sm">
+            <PlusIcon size={10} /> {newButtonText}
           </Button>
         </Flex>
       </Flex>
       <Flex direction="row" align="center" gap={spaces.space4}>
         <InputWithIcon
-          placeholder="Search plans"
+          placeholder={`Search ${heading.toLocaleLowerCase()}`}
           icon={<SearchIcon size={16} />}
           width="fit-content"
           onChange={e => setSearch(e.target.value)}
         />
+        <Button variant="secondary" disabled={isLoading} onClick={refetch}>
+          <RefreshCwIcon size={14} className={isLoading ? 'animate-spin' : ''} />
+        </Button>
       </Flex>
     </Flex>
   )

--- a/modules/web/web-app/features/productCatalog/generic/useCatalogPageProps.tsx
+++ b/modules/web/web-app/features/productCatalog/generic/useCatalogPageProps.tsx
@@ -1,0 +1,45 @@
+import { PaginationState } from '@tanstack/react-table'
+
+import { useDebounceValue } from '@/hooks/useDebounce'
+import { SetQueryStateAction, useQueryRecordState, useQueryState } from '@/hooks/useQueryState'
+import { useTypedParams } from '@/utils/params'
+
+
+
+export const useCatalogPageProps = () => {
+  const paginationState = useQueryRecordState({
+    pageIndex: 0,
+    pageSize: 20,
+  })
+
+  const [pagination] = paginationState
+
+  const [_search, onSearch] = useQueryState<string | undefined>('q', undefined)
+
+  const search = useDebounceValue<string | undefined>(_search, 300)
+
+  const { familyExternalId } = useTypedParams<{ familyExternalId: string }>()
+
+  const paginationQuery = {
+    limit: pagination.pageSize,
+    offset: pagination.pageIndex * pagination.pageSize,
+  }
+
+  return {
+    baseQuery: familyExternalId
+      ? {
+          productFamilyExternalId: familyExternalId,
+          pagination: paginationQuery,
+          search: search,
+        }
+      : undefined,
+
+    paginationState,
+    onSearch,
+  }
+}
+
+export type UsePaginationState = [
+  PaginationState,
+  (value: SetQueryStateAction<PaginationState>) => void,
+]

--- a/modules/web/web-app/features/productCatalog/items/ProductItemsHeader.tsx
+++ b/modules/web/web-app/features/productCatalog/items/ProductItemsHeader.tsx
@@ -1,45 +1,15 @@
-import { spaces } from '@md/foundation'
-import { PlusIcon, SearchIcon } from '@md/icons'
-import { Button, InputWithIcon } from '@md/ui'
-import { Flex } from '@ui/components/legacy'
-import { RefreshCwIcon } from 'lucide-react'
 import { FunctionComponent } from 'react'
 
-import PageHeading from '@/components/PageHeading/PageHeading'
+import { CatalogHeader } from '@/features/productCatalog/generic/CatalogHeader'
 
 interface ProductItemsHeaderProps {
   heading: string
   isLoading: boolean
   refetch: () => void
   setEditPanelVisible: (visible: boolean) => void
+  setSearch: (value: string | undefined) => void
 }
 
-export const ProductItemsHeader: FunctionComponent<ProductItemsHeaderProps> = ({
-  heading,
-  isLoading,
-  refetch,
-  setEditPanelVisible,
-}) => {
-  return (
-    <Flex direction="column" gap={spaces.space9}>
-      <Flex direction="row" align="center" justify="space-between">
-        <PageHeading>{heading}</PageHeading>
-        <Flex direction="row" gap={spaces.space4}>
-          <Button hasIcon variant="primary" onClick={() => setEditPanelVisible(true)} size="sm">
-            <PlusIcon size={10} /> New product
-          </Button>
-        </Flex>
-      </Flex>
-      <Flex direction="row" align="center" gap={spaces.space4}>
-        <InputWithIcon
-          placeholder={`Search ${heading.toLocaleLowerCase()}`}
-          icon={<SearchIcon size={16} />}
-          width="fit-content"
-        />
-        <Button variant="secondary" disabled={isLoading} onClick={refetch}>
-          <RefreshCwIcon size={14} className={isLoading ? 'animate-spin' : ''} />
-        </Button>
-      </Flex>
-    </Flex>
-  )
+export const ProductItemsHeader: FunctionComponent<ProductItemsHeaderProps> = props => {
+  return <CatalogHeader {...props} newButtonText="New product" />
 }

--- a/modules/web/web-app/hooks/useDebounce.tsx
+++ b/modules/web/web-app/hooks/useDebounce.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
-export default function useDebounce<T>(value: T, delay: number): T {
+export function useDebounceValue<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState(value)
 
   useEffect(() => {
@@ -14,4 +14,11 @@ export default function useDebounce<T>(value: T, delay: number): T {
   }, [value, delay])
 
   return debouncedValue
+}
+
+export function useDebounce<T>(initialValue: T, delay: number): [T, (value: T) => void] {
+  const [value, setValue] = useState(initialValue)
+  const debouncedValue = useDebounceValue(value, delay)
+
+  return [debouncedValue, setValue]
 }

--- a/modules/web/web-app/hooks/useZodForm.tsx
+++ b/modules/web/web-app/hooks/useZodForm.tsx
@@ -1,12 +1,13 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { FieldPath, useForm, UseFormProps } from 'react-hook-form'
+import { Control, FieldPath, useForm, UseFormProps, UseFormReturn } from 'react-hook-form'
 import { z } from 'zod'
 
-export function useZodForm<TSchema extends z.ZodTypeAny>(
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export function useZodForm<TSchema extends z.Schema<any, any>>(
   props: Omit<UseFormProps<z.infer<TSchema>>, 'resolver'> & {
     schema: TSchema
   }
-) {
+): Methods<TSchema> {
   const form = useForm({
     mode: 'onBlur',
     ...props,
@@ -18,10 +19,18 @@ export function useZodForm<TSchema extends z.ZodTypeAny>(
     name,
   })
   const withError = (name: FieldPath<z.TypeOf<TSchema>>) => ({
-    error: form.formState.errors[name]?.message,
+    error: form.formState.errors[name]?.message as string | undefined,
   })
 
   return { ...form, withControl, withError }
 }
 
-export type Methods<TSchema extends z.ZodTypeAny> = ReturnType<typeof useZodForm<TSchema>>
+/* eslint-disable @typescript-eslint/no-explicit-any */
+export interface Methods<TSchema extends z.Schema<any, any>>
+  extends UseFormReturn<z.TypeOf<TSchema>, any, z.TypeOf<TSchema>> {
+  withControl: (name: FieldPath<z.TypeOf<TSchema>>) => {
+    control: Control<z.TypeOf<TSchema>, any, z.TypeOf<TSchema>>
+    name: FieldPath<z.TypeOf<TSchema>>
+  }
+  withError: (name: FieldPath<z.TypeOf<TSchema>>) => { error: string | undefined }
+}

--- a/modules/web/web-app/lib/schemas/addons.ts
+++ b/modules/web/web-app/lib/schemas/addons.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+import { FeeTypeSchema } from '@/lib/schemas/plans'
+
+export const createAddonSchema = z.object({
+  name: z.string().min(3),
+  fee: FeeTypeSchema,
+})

--- a/modules/web/web-app/lib/schemas/index.ts
+++ b/modules/web/web-app/lib/schemas/index.ts
@@ -1,9 +1,10 @@
+export * as addons from './addons'
 export * as billableMetrics from './billableMetrics'
 export * as customers from './customers'
+export * as me from './me'
 export * as organizations from './organizations'
 export * as products from './products'
 export * as tokens from './tokens'
-export * as me from './me'
+export { schemas }
 
 import * as schemas from '.'
-export { schemas }

--- a/modules/web/web-app/lib/schemas/plans.ts
+++ b/modules/web/web-app/lib/schemas/plans.ts
@@ -195,7 +195,7 @@ export const OneTimeFeeSchema = z.object({
 })
 export type OneTimeFee = z.infer<typeof OneTimeFeeSchema>
 
-const FeeTypeSchema = z.discriminatedUnion('fee', [
+export const FeeTypeSchema = z.discriminatedUnion('fee', [
   z.object({ fee: z.literal('rate'), data: RateFeeSchema }),
   z.object({ fee: z.literal('slot'), data: SlotFeeSchema }),
   z.object({ fee: z.literal('capacity'), data: CapacityFeeSchema }),
@@ -263,3 +263,12 @@ export const publishedPlanOverviewSchema = z.object({
   name: z.string(),
   description: z.string().optional(),
 })
+
+export const trialConfigSchema = z.object({
+  durationDays: z.number().int(),
+  downgradePlanId: z.string().uuid().optional(),
+  trialingPlanId: z.string().uuid().optional(),
+  requiresPreAuthorization: z.boolean().optional(),
+  actionAfterTrial: z.enum(['BLOCK', 'CHARGE', 'DOWNGRADE']).optional(),
+})
+export type TrialConfigSchema = z.infer<typeof trialConfigSchema>

--- a/modules/web/web-app/pages/tenants/billing/addons.tsx
+++ b/modules/web/web-app/pages/tenants/billing/addons.tsx
@@ -1,58 +1,7 @@
-import { disableQuery } from '@connectrpc/connect-query'
-import { spaces } from '@md/foundation'
-import { Flex } from '@ui/components/legacy'
-import { FunctionComponent, useState } from 'react'
+import { FunctionComponent } from 'react'
 
-import { ProductEditPanel } from '@/features/productCatalog/items/ProductEditPanel'
-import { ProductItemsHeader } from '@/features/productCatalog/items/ProductItemsHeader'
-import { ProductItemsTable } from '@/features/productCatalog/items/ProductItemsTable'
-import { useQuery } from '@/lib/connectrpc'
-import { listProducts } from '@/rpc/api/products/v1/products-ProductsService_connectquery'
-import { useTypedParams } from '@/utils/params'
-
-import type { PaginationState } from '@tanstack/react-table'
+import { AddonsPage } from '@/features/productCatalog/addons/AddonsPage'
 
 export const Addons: FunctionComponent = () => {
-  const [editPanelVisible, setEditPanelVisible] = useState(false)
-  const [pagination, setPagination] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 20,
-  })
-
-  const { familyExternalId } = useTypedParams<{ familyExternalId: string }>()
-
-  const productsQuery = useQuery(
-    listProducts,
-    familyExternalId
-      ? {
-          familyExternalId,
-        }
-      : disableQuery
-  )
-  const data = productsQuery.data?.products ?? []
-  const isLoading = productsQuery.isLoading
-  const totalCount = productsQuery.data?.paginationMeta?.total ?? 0
-
-  const refetch = () => {
-    productsQuery.refetch()
-  }
-
-  return (
-    <Flex direction="column" gap={spaces.space9}>
-      <ProductItemsHeader
-        heading="Addons"
-        setEditPanelVisible={setEditPanelVisible}
-        isLoading={isLoading}
-        refetch={refetch}
-      />
-      <ProductItemsTable
-        data={data}
-        pagination={pagination}
-        setPagination={setPagination}
-        totalCount={totalCount}
-        isLoading={isLoading}
-      />
-      <ProductEditPanel visible={editPanelVisible} closePanel={() => setEditPanelVisible(false)} />
-    </Flex>
-  )
+  return <AddonsPage />
 }

--- a/modules/web/web-app/pages/tenants/billing/plans.tsx
+++ b/modules/web/web-app/pages/tenants/billing/plans.tsx
@@ -5,14 +5,16 @@ import { FunctionComponent, useState } from 'react'
 import { PlanCreateInitModal } from '@/features/billing/plans/PlanCreateInitModal'
 import { PlansHeader } from '@/features/billing/plans/PlansHeader'
 import { PlansTable } from '@/features/billing/plans/PlansTable'
+import { useDebounce } from '@/hooks/useDebounce'
 
 export const Plans: FunctionComponent = () => {
   const [createModalOpened, setCreateModalOpened] = useState(false)
+  const [search, setSearch] = useDebounce<string | undefined>(undefined, 200)
 
   return (
     <Flex direction="column" gap={spaces.space9}>
-      <PlansHeader setEditPanelVisible={() => setCreateModalOpened(true)} />
-      <PlansTable />
+      <PlansHeader setEditPanelVisible={() => setCreateModalOpened(true)} setSearch={setSearch} />
+      <PlansTable search={search} />
       <PlanCreateInitModal
         modalVisible={createModalOpened}
         setModalVisible={setCreateModalOpened}

--- a/modules/web/web-app/pages/tenants/catalog/productItems.tsx
+++ b/modules/web/web-app/pages/tenants/catalog/productItems.tsx
@@ -2,6 +2,7 @@ import { disableQuery } from '@connectrpc/connect-query'
 import { spaces } from '@md/foundation'
 import { Flex } from '@ui/components/legacy'
 import { Fragment, FunctionComponent, useState } from 'react'
+import { toast } from 'sonner'
 
 import { ProductEditPanel } from '@/features/productCatalog/items/ProductEditPanel'
 import { ProductItemsHeader } from '@/features/productCatalog/items/ProductItemsHeader'
@@ -41,6 +42,9 @@ export const ProductItems: FunctionComponent = () => {
           setEditPanelVisible={setEditPanelVisible}
           isLoading={isLoading}
           refetch={refetch}
+          setSearch={() => {
+            toast.error('Search not implemented')
+          }}
         />
         <ProductItemsTable
           data={data}

--- a/modules/web/web-app/pages/tenants/customer/customers.tsx
+++ b/modules/web/web-app/pages/tenants/customer/customers.tsx
@@ -4,7 +4,7 @@ import { Fragment, FunctionComponent, useState } from 'react'
 
 import { TenantPageLayout } from '@/components/layouts'
 import { CustomersEditPanel, CustomersHeader, CustomersTable } from '@/features/customers'
-import useDebounce from '@/hooks/useDebounce'
+import { useDebounceValue } from '@/hooks/useDebounce'
 import { useQuery } from '@/lib/connectrpc'
 import { listCustomers } from '@/rpc/api/customers/v1/customers-CustomersService_connectquery'
 import { ListCustomerRequest_SortBy } from '@/rpc/api/customers/v1/customers_pb'
@@ -15,7 +15,7 @@ export const Customers: FunctionComponent = () => {
   const [editPanelVisible, setEditPanelVisible] = useState(false)
   const [search, setSearch] = useState('')
 
-  const debouncedSearch = useDebounce(search, 400)
+  const debouncedSearch = useDebounceValue(search, 400)
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,

--- a/modules/web/web-app/pages/tenants/invoice/Invoices.tsx
+++ b/modules/web/web-app/pages/tenants/invoice/Invoices.tsx
@@ -4,7 +4,7 @@ import { Fragment, useState } from 'react'
 
 import { InvoicesHeader, InvoicesTable } from '@/features/invoices'
 import { InvoicesSearch } from '@/features/invoices/types'
-import useDebounce from '@/hooks/useDebounce'
+import { useDebounceValue } from '@/hooks/useDebounce'
 import { useQuery } from '@/lib/connectrpc'
 import { listInvoices } from '@/rpc/api/invoices/v1/invoices-InvoicesService_connectquery'
 import { ListInvoicesRequest_SortBy } from '@/rpc/api/invoices/v1/invoices_pb'
@@ -15,7 +15,7 @@ export const Invoices = () => {
   const [, setEditPanelVisible] = useState(false)
   const [search, setSearch] = useState<InvoicesSearch>({})
 
-  const debouncedSearch = useDebounce(search, 400)
+  const debouncedSearch = useDebounceValue(search, 400)
 
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,


### PR DESCRIPTION
This PR adds trial configuration in plans (what plan is resolved during the trial, what action after the trial (block/charge/downgrade), what plan is resolved after downgrading), free trial or "paid trial" (so trial of an upper plan while paying for the current plan)

A second PR will follow with the subscription-related part (mostly about resolving the trial for an existing subscription) 

(there's a few commented out FE files related to addons, no impact, impl is coming in another pr)