### PR TITLE
chore: only run rust CI if rust code changes

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -10,7 +10,6 @@ on:
     paths:
       - ".github/workflows/ci-rust.yaml"
       - "Cargo.*"
-      - "modules/meteroid/proto/**"
       - "crates/**"
       - "extra/**"
       - "modules/meteroid/**"

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -6,7 +6,16 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, reopened, synchronize ]
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/workflows/ci-rust.yaml"
+      - "Cargo.*"
+      - "modules/meteroid/proto/**"
+      - "crates/**"
+      - "extra/**"
+      - "modules/meteroid/**"
+      - "modules/metering/**"
+      - "modules/adapters/**"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"


### PR DESCRIPTION
similar to what we do for the FE CI builds, only run rust CI on change in one of the rust modules or config