### PR TITLE
fix: use strict version of svix 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,7 @@ serde_qs = "0.13.0"
 serde_yaml = "0.9.30"
 sha2 = "0.10.8"
 shellexpand = "3.1.0"
-svix = { version = "1.41.0", default-features = false }
+svix = { version = "=1.41.0", default-features = false }
 syn = "2.0.52"
 strum = { version = "0.26", default-features = false }
 tap = "1.0.1"


### PR DESCRIPTION
## Description
Cargo automatically upgrades to 1.42.0 and it causes compilation issues due to API change (non-backward compatible)

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
