### PR TITLE
chore: Change the webhook event schema

### DIFF
--- a/docker/develop/init-debezium-connectors.sh
+++ b/docker/develop/init-debezium-connectors.sh
@@ -22,7 +22,7 @@ localhost:8083/connectors \
     "transforms": "outbox",
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
     "transforms.outbox.table.expand.json.payload": "true",
-    "transforms.outbox.table.fields.additional.placement": "event_type:header:event_type,tenant_id:header:tenant_id",
+    "transforms.outbox.table.fields.additional.placement": "event_type:header:event_type,tenant_id:header:tenant_id,local_id:header:local_id",
     "transforms.outbox.route.topic.replacement": "outbox.event.${routedByValue}",
     "transforms.outbox.table.field.event.key": "aggregate_id",
     "transforms.outbox.route.by.field": "aggregate_type",

--- a/modules/meteroid/crates/diesel-models/src/outbox_event.rs
+++ b/modules/meteroid/crates/diesel-models/src/outbox_event.rs
@@ -12,4 +12,5 @@ pub struct OutboxEventRowNew {
     pub aggregate_type: String,
     pub event_type: String,
     pub payload: Option<serde_json::Value>,
+    pub local_id: String,
 }

--- a/modules/meteroid/crates/diesel-models/src/schema.rs
+++ b/modules/meteroid/crates/diesel-models/src/schema.rs
@@ -459,6 +459,7 @@ diesel::table! {
         event_type -> Text,
         payload -> Nullable<Jsonb>,
         created_at -> Timestamp,
+        local_id -> Text,
     }
 }
 

--- a/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
@@ -169,15 +169,19 @@ pub enum UnitConversionRoundingEnum {
     None,
 }
 
-#[derive(Debug, Clone, PartialEq, Display, EnumIter, EnumString)]
+#[derive(Debug, Clone, PartialEq, Display, EnumIter, EnumString, Serialize)]
 pub enum WebhookOutEventTypeEnum {
     #[strum(serialize = "customer.created")]
+    #[serde(rename = "customer.created")]
     CustomerCreated,
     #[strum(serialize = "subscription.created")]
+    #[serde(rename = "subscription.created")]
     SubscriptionCreated,
     #[strum(serialize = "invoice.created")]
+    #[serde(rename = "invoice.created")]
     InvoiceCreated,
     #[strum(serialize = "invoice.finalized")]
+    #[serde(rename = "invoice.finalized")]
     InvoiceFinalized,
 }
 

--- a/modules/meteroid/crates/meteroid-store/src/domain/outbox_event.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/outbox_event.rs
@@ -1,5 +1,6 @@
 use crate::domain::{Address, Customer, ShippingAddress};
 use crate::errors::{StoreError, StoreErrorReport};
+use crate::utils::local_id::{IdType, LocalId};
 use crate::StoreResult;
 use diesel_models::outbox_event::OutboxEventRowNew;
 use error_stack::Report;
@@ -86,6 +87,7 @@ impl TryInto<OutboxEventRowNew> for OutboxEvent {
     fn try_into(self) -> Result<OutboxEventRowNew, Self::Error> {
         Ok(OutboxEventRowNew {
             id: Uuid::now_v7(),
+            local_id: LocalId::generate_for(IdType::Event),
             tenant_id: self.tenant_id,
             aggregate_id: self.aggregate_id.to_string(),
             aggregate_type: self.event_type.aggregate_type(),

--- a/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
@@ -6,6 +6,7 @@ use diesel_models::webhooks::{WebhookInEventRow, WebhookInEventRowNew};
 use error_stack::Report;
 use o2o::o2o;
 use secrecy::SecretString;
+use serde::Serialize;
 use url::Url;
 use uuid::Uuid;
 
@@ -125,26 +126,41 @@ impl From<WebhookOutStatusCodeClass> for svix::api::StatusCodeClass {
     }
 }
 
+#[derive(Clone, Debug, Serialize)]
+/// The message that is sent to the webhook
 pub struct WebhookOutMessageNew {
-    /// used as dedupe id
-    pub event_id: Option<String>,
+    pub id: String,
+    #[serde(rename = "type")]
     pub event_type: WebhookOutEventTypeEnum,
     pub payload: serde_json::Value,
+    pub created_at: String,
 }
 
-impl From<WebhookOutMessageNew> for svix::api::MessageIn {
-    fn from(value: WebhookOutMessageNew) -> Self {
-        svix::api::MessageIn {
+impl TryFrom<WebhookOutMessageNew> for svix::api::MessageIn {
+    type Error = Report<StoreError>;
+    fn try_from(value: WebhookOutMessageNew) -> Result<Self, Self::Error> {
+        let event_id = Some(value.id.clone());
+        let event_type = value.event_type.to_string();
+        let payload = serde_json::to_value(value).map_err(|e| {
+            Report::from(StoreError::SerdeError(
+                "Failed to serialize payload".to_string(),
+                e,
+            ))
+        })?;
+
+        let msg = svix::api::MessageIn {
             application: None,
             channels: None,
-            event_id: value.event_id,
-            event_type: value.event_type.to_string(),
-            payload: value.payload,
+            event_id,
+            event_type,
+            payload,
             payload_retention_hours: None,
             payload_retention_period: None,
             tags: None,
             transformations_params: None,
-        }
+        };
+
+        Ok(msg)
     }
 }
 

--- a/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
@@ -132,8 +132,14 @@ pub struct WebhookOutMessageNew {
     pub id: String,
     #[serde(rename = "type")]
     pub event_type: WebhookOutEventTypeEnum,
-    pub payload: serde_json::Value,
+    pub payload: WebhookOutMessagePayload,
     pub created_at: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "object", rename_all = "snake_case")]
+pub enum WebhookOutMessagePayload {
+    Customer(serde_json::Value),
 }
 
 impl TryFrom<WebhookOutMessageNew> for svix::api::MessageIn {

--- a/modules/meteroid/crates/meteroid-store/src/repositories/webhooks.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/webhooks.rs
@@ -178,7 +178,7 @@ impl WebhooksInterface for Store {
         if let Some(svix_api) = &self.svix {
             let message_result = svix_api
                 .message()
-                .create(tenant_id.to_string(), msg.into(), None)
+                .create(tenant_id.to_string(), msg.try_into()?, None)
                 .await;
 
             if let Err(Error::Http(ref e)) = message_result {

--- a/modules/meteroid/crates/meteroid-store/src/utils/local_id.rs
+++ b/modules/meteroid/crates/meteroid-store/src/utils/local_id.rs
@@ -14,6 +14,7 @@ pub enum IdType {
     Product,
     Subscription,
     Tenant,
+    Event,
 }
 
 impl IdType {
@@ -23,6 +24,7 @@ impl IdType {
             IdType::BillableMetric => "bm_",
             IdType::Coupon => "cou_",
             IdType::Customer => "cus_",
+            IdType::Event => "evt_",
             IdType::Invoice => "inv_",
             IdType::InvoicingEntity => "ive_",
             IdType::Plan => "plan_",
@@ -36,7 +38,7 @@ impl IdType {
 }
 
 /**
- * Generates a local id for a given type. Local ids are small human readable ids for the API, unique per tenant
+ * Generates a local id for a given type. Local ids are small human-readable ids for the API, unique per tenant
  */
 pub struct LocalId;
 

--- a/modules/meteroid/migrations/diesel/2024-12-06-061037_outbox_event_local_id/down.sql
+++ b/modules/meteroid/migrations/diesel/2024-12-06-061037_outbox_event_local_id/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "outbox_event" DROP COLUMN "local_id";

--- a/modules/meteroid/migrations/diesel/2024-12-06-061037_outbox_event_local_id/up.sql
+++ b/modules/meteroid/migrations/diesel/2024-12-06-061037_outbox_event_local_id/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "outbox_event"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");

--- a/modules/meteroid/src/workers/kafka/webhook.rs
+++ b/modules/meteroid/src/workers/kafka/webhook.rs
@@ -5,7 +5,9 @@ use chrono::SecondsFormat;
 use error_stack::Report;
 use meteroid_store::domain::enums::WebhookOutEventTypeEnum;
 use meteroid_store::domain::outbox_event::CustomerCreatedEvent;
-use meteroid_store::domain::webhooks::{WebhookOutCreateMessageResult, WebhookOutMessageNew};
+use meteroid_store::domain::webhooks::{
+    WebhookOutCreateMessageResult, WebhookOutMessageNew, WebhookOutMessagePayload,
+};
 use meteroid_store::domain::{Address, ShippingAddress};
 use meteroid_store::errors::StoreError;
 use meteroid_store::repositories::webhooks::WebhooksInterface;
@@ -112,7 +114,7 @@ impl TryInto<Option<WebhookOutMessageNew>> for OutboxEvent {
                     ))
                 })?;
 
-                (event_type, payload)
+                (event_type, WebhookOutMessagePayload::Customer(payload))
             }
             _ => return Ok(None),
         };


### PR DESCRIPTION
## Description
Schema example below (the payload schema will depend on the type, the object field inside payload is the discriminator)
```json
{
  "created_at": "2024-12-04T10:29:21.180Z",
  "id": "evt_xxxxxxxxxxxxy",
  "payload": {
    "alias": null,
    "billing_address": null,
    "currency": "EUR",
    "email": null,
    "id": "cus_xxxxxxxxxxxxx",
    "invoicing_email": null,
    "name": "test_cust",
    "object": "customer", // discriminator
    "phone": null,
    "shipping_address": null
  },
  "type": "customer.created"
}
```

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
