### PR TITLE
feat: Svix webhook portal access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ async-trait = "0.1.74"
 axum = { version = "0.8.1", features = ["json", "query", "tower-log", "http1"] }
 base62 = "2.0.2"
 base64 = "0.22.0"
+backon = "1.3.0"
 build-info = "0.0.39"
 build-info-build = "0.0.39"
 bytes = "1.5.0"
@@ -72,6 +73,7 @@ fluent-static-codegen = "0.6.0"
 futures = "0.3.28"
 futures-lite = "2.3.0"
 futures-util = { version = "0.3.29", features = [] }
+governor = "0.8.0"
 hex = "0.4.3"
 hmac = "0.12.1"
 hmac-sha256 = "1.1.7"
@@ -91,6 +93,7 @@ moka = { version = "0.12.3", features = ["log", "logging", "sync"] }
 nanoid = "0.4.0"
 ndarray = "0.16.1"
 ndarray-interp = { git = "https://github.com/jonasBoss/ndarray-interp", rev = "a31b3ea48e478424fee653f86367475bb65afded" }
+nonzero_ext = { version = "0.3.0", default-features = false }
 oauth2 = "5.0.0"
 o2o = "0.5.0"
 object_store = { version = "0.11.0", default-features = false }

--- a/modules/meteroid/crates/meteroid-store/Cargo.toml
+++ b/modules/meteroid/crates/meteroid-store/Cargo.toml
@@ -13,6 +13,7 @@ common-eventbus.workspace = true
 
 argon2 = { workspace = true }
 base62.workspace = true
+backon = { workspace = true }
 cached = { workspace = true, features = ["async", "tokio"] }
 chrono = { workspace = true, features = ["clock", "serde"] }
 diesel.workspace = true
@@ -35,6 +36,8 @@ common-utils = { workspace = true, features = ["decimal"] }
 itertools.workspace = true
 secrecy = { workspace = true, features = ["serde"] }
 svix = { workspace = true, features = ["http2", "rustls-tls"] }
+governor = { workspace = true }
+nonzero_ext = { workspace = true }
 chacha20poly1305 = { workspace = true }
 hex = { workspace = true }
 url = { workspace = true }

--- a/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::str::FromStr;
 use strum::{Display, EnumIter, EnumString};
+use svix::api::EndpointOut;
 
 #[derive(o2o, Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 #[map_owned(diesel_enums::ActionAfterTrialEnum)]
@@ -183,7 +184,7 @@ pub enum UnitConversionRoundingEnum {
     None,
 }
 
-#[derive(Debug, Clone, PartialEq, Display, EnumIter, EnumString, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Display, EnumIter, EnumString, Serialize)]
 pub enum WebhookOutEventTypeEnum {
     #[strum(serialize = "customer.created")]
     #[serde(rename = "customer.created")]
@@ -200,10 +201,8 @@ pub enum WebhookOutEventTypeEnum {
 }
 
 impl WebhookOutEventTypeEnum {
-    pub fn from_svix_channels(
-        channels: &Option<Vec<String>>,
-    ) -> StoreResult<Vec<WebhookOutEventTypeEnum>> {
-        channels
+    pub fn from_svix_endpoint(ep: &EndpointOut) -> StoreResult<Vec<WebhookOutEventTypeEnum>> {
+        ep.filter_types
             .as_ref()
             .unwrap_or(&vec![])
             .iter()

--- a/modules/meteroid/crates/meteroid-store/src/domain/misc.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/misc.rs
@@ -114,6 +114,7 @@ pub enum OrderByRequest {
     NameDesc,
 }
 
+#[derive(Debug, Clone)]
 pub struct WebhookPage<T> {
     pub data: Vec<T>,
     pub done: bool,

--- a/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/webhooks.rs
@@ -37,13 +37,15 @@ impl TryFrom<svix::api::EndpointOut> for WebhookOutEndpointListItem {
     type Error = Report<StoreError>;
 
     fn try_from(value: svix::api::EndpointOut) -> Result<Self, Self::Error> {
+        let events_to_listen = WebhookOutEventTypeEnum::from_svix_endpoint(&value)?;
+
         Ok(WebhookOutEndpointListItem {
             id: value.id,
             url: value.url,
             description: Some(value.description),
             created_at: value.created_at,
             updated_at: value.updated_at,
-            events_to_listen: WebhookOutEventTypeEnum::from_svix_channels(&value.channels)?,
+            events_to_listen,
             disabled: value.disabled.unwrap_or(false),
         })
     }
@@ -133,7 +135,6 @@ pub struct WebhookOutMessageNew {
     #[serde(rename = "type")]
     pub event_type: WebhookOutEventTypeEnum,
     pub payload: WebhookOutMessagePayload,
-    pub created_at: String,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -172,6 +173,7 @@ impl TryFrom<WebhookOutMessageNew> for svix::api::MessageIn {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct WebhookOutMessage {
     pub event_type: String,
     pub id: String,
@@ -271,6 +273,7 @@ impl From<WebhookOutListEndpointFilter> for svix::api::EndpointListOptions {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum WebhookOutCreateMessageResult {
     Conflict,
     NotFound,
@@ -302,4 +305,11 @@ pub struct WebhookInEvent {
     pub attempts: i32,
     pub error: Option<String>,
     pub provider_config_id: Uuid,
+}
+
+#[derive(Clone, Debug, o2o)]
+#[from_owned(svix::api::AppPortalAccessOut)]
+pub struct WebhookPortalAccess {
+    pub token: String,
+    pub url: String,
 }

--- a/modules/meteroid/crates/meteroid-store/src/store.rs
+++ b/modules/meteroid/crates/meteroid-store/src/store.rs
@@ -20,9 +20,8 @@ use rustls::{DigitallySignedStruct, Error, SignatureScheme};
 use std::str::FromStr;
 use std::sync::Arc;
 use stripe_client::client::StripeClient;
-use svix::api::{ApplicationIn, ApplicationOut, Svix};
+use svix::api::Svix;
 use tokio_postgres_rustls::MakeRustlsConnect;
-use uuid::Uuid;
 
 pub type PgPool = Pool<AsyncPgConnection>;
 pub type PgConn = Object<AsyncPgConnection>;
@@ -188,25 +187,6 @@ impl Store {
         self.svix
             .clone()
             .ok_or(StoreError::InitializationError("svix client config".into()).into())
-    }
-
-    pub(crate) async fn svix_application(&self, tenant_id: Uuid) -> StoreResult<ApplicationOut> {
-        let svix = self.svix()?;
-        let app_name = format!("tenant-{}", tenant_id);
-        svix.application()
-            .get_or_create(
-                ApplicationIn {
-                    metadata: None,
-                    name: app_name,
-                    rate_limit: None,
-                    uid: Some(tenant_id.to_string()),
-                },
-                None,
-            )
-            .await
-            .change_context(StoreError::WebhookServiceError(
-                "Failed to get or create svix application".into(),
-            ))
     }
 }
 

--- a/modules/meteroid/proto/api/webhooksout/v1/webhooksout.proto
+++ b/modules/meteroid/proto/api/webhooksout/v1/webhooksout.proto
@@ -34,8 +34,15 @@ message GetWebhookEndpointResponse {
   WebhookEndpoint endpoint = 1;
 }
 
+message WebhookPortalAccessRequest {}
+message WebhookPortalAccessResponse {
+  string url = 1;
+  string token = 2;
+}
+
 service WebhooksService {
   rpc CreateWebhookEndpoint(CreateWebhookEndpointRequest) returns (CreateWebhookEndpointResponse) {};
   rpc GetWebhookEndpoint(GetWebhookEndpointRequest) returns (GetWebhookEndpointResponse) {};
   rpc ListWebhookEndpoints(ListWebhookEndpointsRequest) returns (ListWebhookEndpointsResponse) {};
+  rpc GetWebhookPortalAccess(WebhookPortalAccessRequest) returns (WebhookPortalAccessResponse) {};
 }

--- a/modules/meteroid/src/api/webhooksout/service.rs
+++ b/modules/meteroid/src/api/webhooksout/service.rs
@@ -5,6 +5,7 @@ use meteroid_grpc::meteroid::api::webhooks::out::v1::webhooks_service_server::We
 use meteroid_grpc::meteroid::api::webhooks::out::v1::{
     CreateWebhookEndpointRequest, CreateWebhookEndpointResponse, GetWebhookEndpointRequest,
     GetWebhookEndpointResponse, ListWebhookEndpointsRequest, ListWebhookEndpointsResponse,
+    WebhookPortalAccessRequest, WebhookPortalAccessResponse,
 };
 use meteroid_store::repositories::webhooks::WebhooksInterface;
 
@@ -78,5 +79,24 @@ impl WebhooksService for WebhooksServiceComponents {
             .map_err(Into::<WebhookApiError>::into)?;
 
         Ok(Response::new(page))
+    }
+
+    async fn get_webhook_portal_access(
+        &self,
+        request: Request<WebhookPortalAccessRequest>,
+    ) -> Result<Response<WebhookPortalAccessResponse>, Status> {
+        let tenant_id = request.tenant()?;
+
+        let resp = self
+            .store
+            .get_webhook_portal_access(tenant_id)
+            .await
+            .map(|x| WebhookPortalAccessResponse {
+                url: x.url,
+                token: x.token,
+            })
+            .map_err(Into::<WebhookApiError>::into)?;
+
+        Ok(Response::new(resp))
     }
 }

--- a/modules/meteroid/src/workers/kafka/outbox.rs
+++ b/modules/meteroid/src/workers/kafka/outbox.rs
@@ -1,4 +1,3 @@
-use chrono::{DateTime, Utc};
 use meteroid_store::domain::outbox_event::{CustomerEvent, InvoiceEvent, SubscriptionEvent};
 use rdkafka::message::{BorrowedHeaders, BorrowedMessage, Headers};
 use rdkafka::Message;
@@ -11,7 +10,6 @@ pub struct OutboxEvent {
     pub tenant_id: Uuid,
     pub aggregate_id: String,
     pub event_type: EventType,
-    pub event_timestamp: DateTime<Utc>,
 }
 
 #[derive(Debug)]
@@ -64,14 +62,11 @@ pub(crate) fn parse_outbox_event(m: &BorrowedMessage<'_>) -> Option<OutboxEvent>
 
     let event_type = EventType::from_kafka_message(m)?;
 
-    let event_timestamp = DateTime::from_timestamp_millis(m.timestamp().to_millis()?)?;
-
     Some(OutboxEvent {
         id,
         tenant_id,
         aggregate_id,
         event_type,
-        event_timestamp,
     })
 }
 

--- a/modules/meteroid/src/workers/kafka/webhook.rs
+++ b/modules/meteroid/src/workers/kafka/webhook.rs
@@ -209,13 +209,10 @@ impl TryInto<Option<WebhookOutMessageNew>> for OutboxEvent {
             _ => return Ok(None),
         };
 
-        let created_at = format_utc(&self.event_timestamp);
-
         let webhook = WebhookOutMessageNew {
             id: self.id,
             event_type,
             payload,
-            created_at,
         };
 
         Ok(Some(webhook))


### PR DESCRIPTION
## Description
 - expose an grpc api that returns the svix customer portal link so we can embed customer portal in FE
 - reduce calls to svix-api 
   - send only messages that have active endpoints that listen to the message event_type
   - use in-memory rate-limiter: tactical solution, ok for now as the webhook message sender is running in a single node ATM.

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
