### PR TITLE
chore: Pin rust version in CI and docker

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -68,6 +68,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.85.0
+        with:
+          components: rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1

--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -49,9 +49,7 @@ jobs:
           sudo mv bin/protoc /usr/local/bin
           sudo mv include/google /usr/local/include
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -69,9 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
@@ -89,10 +85,9 @@ jobs:
           unzip protoc*.zip
           sudo mv bin/protoc /usr/local/bin
           sudo mv include/google /usr/local/include
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.85.0
         with:
           components: clippy
-          toolchain: stable
       - uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7
@@ -113,9 +108,7 @@ jobs:
           sudo mv bin/protoc /usr/local/bin
           sudo mv include/google /usr/local/include
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
+        uses: dtolnay/rust-toolchain@1.85.0
       - uses: Swatinem/rust-cache@v2
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.7

--- a/modules/metering/Dockerfile
+++ b/modules/metering/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.85.0-bookworm AS chef
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 WORKDIR /opt/src

--- a/modules/meteroid/api.Dockerfile
+++ b/modules/meteroid/api.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.85.0-bookworm AS chef
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 WORKDIR /opt/src

--- a/modules/meteroid/scheduler.Dockerfile
+++ b/modules/meteroid/scheduler.Dockerfile
@@ -1,5 +1,5 @@
 
-FROM lukemathwalker/cargo-chef:latest-rust-1-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.85.0-bookworm AS chef
 ARG CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 ENV CARGO_NET_GIT_FETCH_WITH_CLI=true
 WORKDIR /opt/src


### PR DESCRIPTION
## Description
By using latest stable rust version we run into issues where our code might use different rust versions in cargo, ci, and docker. Pinning it allows a more controlled rust update.

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
