### PR TITLE
chore: Remove local_id

### DIFF
--- a/crates/common-domain/src/ids/mod.rs
+++ b/crates/common-domain/src/ids/mod.rs
@@ -16,6 +16,17 @@ id_type!(TenantId, "ten_");
 id_type!(CustomerId, "cus_");
 id_type!(SubscriptionId, "sub_");
 id_type!(InvoiceId, "inv_");
+id_type!(InvoicingEntityId, "ive_");
+id_type!(AddOnId, "add_");
+id_type!(BankAccountId, "ba_");
+id_type!(BillableMetricId, "bm_");
+id_type!(CouponId, "cou_");
+id_type!(CreditNoteId, "crn_");
+id_type!(EventId, "evt_");
+id_type!(ProductFamilyId, "pf_");
+id_type!(ProductId, "prd_");
+id_type!(PriceComponentId, "price_");
+id_type!(PlanId, "plan_");
 
 #[derive(Debug)]
 pub struct IdError(pub(crate) String);

--- a/docker/develop/init-debezium-connectors.sh
+++ b/docker/develop/init-debezium-connectors.sh
@@ -25,7 +25,7 @@ localhost:8083/connectors \
     "transforms": "outbox",
     "transforms.outbox.type": "io.debezium.transforms.outbox.EventRouter",
     "transforms.outbox.table.expand.json.payload": "true",
-    "transforms.outbox.table.fields.additional.placement": "event_type:header:event_type,tenant_id:header:tenant_id,local_id:header:local_id",
+    "transforms.outbox.table.fields.additional.placement": "event_type:header:event_type,tenant_id:header:tenant_id,id:header:id",
     "transforms.outbox.route.topic.replacement": "outbox.event.${routedByValue}",
     "transforms.outbox.table.field.event.key": "aggregate_id",
     "transforms.outbox.route.by.field": "aggregate_type",

--- a/modules/meteroid/crates/diesel-models/src/add_ons.rs
+++ b/modules/meteroid/crates/diesel-models/src/add_ons.rs
@@ -1,30 +1,27 @@
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{AddOnId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
-use uuid::Uuid;
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
 #[diesel(table_name = crate::schema::add_on)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AddOnRow {
-    pub id: Uuid,
+    pub id: AddOnId,
     pub name: String,
     pub fee: serde_json::Value,
     pub tenant_id: TenantId,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
-    pub local_id: String,
 }
 
 #[derive(Debug, Default, Insertable)]
 #[diesel(table_name = crate::schema::add_on)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AddOnRowNew {
-    pub id: Uuid,
+    pub id: AddOnId,
     pub name: String,
     pub fee: serde_json::Value,
     pub tenant_id: TenantId,
-    pub local_id: String,
 }
 
 #[derive(AsChangeset)]
@@ -32,7 +29,7 @@ pub struct AddOnRowNew {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id, tenant_id))]
 pub struct AddOnRowPatch {
-    pub id: Uuid,
+    pub id: AddOnId,
     pub tenant_id: TenantId,
     pub name: Option<String>,
     pub fee: Option<serde_json::Value>,

--- a/modules/meteroid/crates/diesel-models/src/applied_coupons.rs
+++ b/modules/meteroid/crates/diesel-models/src/applied_coupons.rs
@@ -1,5 +1,5 @@
 use crate::coupons::CouponRow;
-use common_domain::ids::{CustomerId, SubscriptionId};
+use common_domain::ids::{CouponId, CustomerId, PlanId, SubscriptionId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 use rust_decimal::Decimal;
 use uuid::Uuid;
@@ -9,7 +9,7 @@ use uuid::Uuid;
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AppliedCouponRow {
     pub id: Uuid,
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
     pub customer_id: CustomerId,
     pub subscription_id: SubscriptionId,
     pub is_active: bool,
@@ -24,7 +24,7 @@ pub struct AppliedCouponRow {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AppliedCouponForDisplayRow {
     pub id: Uuid,
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
     pub customer_id: CustomerId,
     #[diesel(select_expression = crate::schema::customer::name)]
     #[diesel(select_expression_type = crate::schema::customer::name)]
@@ -32,10 +32,7 @@ pub struct AppliedCouponForDisplayRow {
     pub subscription_id: SubscriptionId,
     #[diesel(select_expression = crate::schema::plan::id)]
     #[diesel(select_expression_type = crate::schema::plan::id)]
-    pub plan_id: Uuid,
-    #[diesel(select_expression = crate::schema::plan::local_id)]
-    #[diesel(select_expression_type = crate::schema::plan::local_id)]
-    pub plan_local_id: String,
+    pub plan_id: PlanId,
     #[diesel(select_expression = crate::schema::plan_version::version)]
     #[diesel(select_expression_type = crate::schema::plan_version::version)]
     pub plan_version: i32,
@@ -54,7 +51,7 @@ pub struct AppliedCouponForDisplayRow {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct AppliedCouponRowNew {
     pub id: Uuid,
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
     pub customer_id: CustomerId,
     pub subscription_id: SubscriptionId,
     pub is_active: bool,

--- a/modules/meteroid/crates/diesel-models/src/bank_accounts.rs
+++ b/modules/meteroid/crates/diesel-models/src/bank_accounts.rs
@@ -1,6 +1,6 @@
 use crate::enums::BankAccountFormat;
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BankAccountId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 use uuid::Uuid;
 
@@ -8,8 +8,7 @@ use uuid::Uuid;
 #[diesel(table_name = crate::schema::bank_account)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct BankAccountRow {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub currency: String,
     pub country: String,
@@ -24,8 +23,7 @@ pub struct BankAccountRow {
 #[diesel(table_name = crate::schema::bank_account)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct BankAccountRowNew {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub created_by: Uuid,
     pub currency: String,
@@ -40,7 +38,7 @@ pub struct BankAccountRowNew {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id, tenant_id))]
 pub struct BankAccountRowPatch {
-    pub id: Uuid,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub currency: Option<String>,
     pub country: Option<String>,

--- a/modules/meteroid/crates/diesel-models/src/billable_metrics.rs
+++ b/modules/meteroid/crates/diesel-models/src/billable_metrics.rs
@@ -3,14 +3,14 @@ use uuid::Uuid;
 
 use crate::enums::{BillingMetricAggregateEnum, UnitConversionRoundingEnum};
 
-use common_domain::ids::TenantId;
+use common_domain::ids::{BillableMetricId, ProductFamilyId, ProductId, TenantId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Debug, Identifiable, Queryable, Selectable)]
 #[diesel(table_name = crate::schema::billable_metric)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct BillableMetricRow {
-    pub id: Uuid,
+    pub id: BillableMetricId,
     pub name: String,
     pub description: Option<String>,
     pub code: String,
@@ -25,16 +25,15 @@ pub struct BillableMetricRow {
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub product_id: Option<Uuid>,
-    pub local_id: String,
+    pub product_family_id: ProductFamilyId,
+    pub product_id: Option<ProductId>,
 }
 
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = crate::schema::billable_metric)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct BillableMetricRowNew {
-    pub id: Uuid,
+    pub id: BillableMetricId,
     pub name: String,
     pub description: Option<String>,
     pub code: String,
@@ -46,17 +45,15 @@ pub struct BillableMetricRowNew {
     pub usage_group_key: Option<String>,
     pub created_by: Uuid,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub product_id: Option<Uuid>,
-    pub local_id: String,
+    pub product_family_id: ProductFamilyId,
+    pub product_id: Option<ProductId>,
 }
 
 #[derive(Debug, Identifiable, Queryable, Selectable)]
 #[diesel(table_name = crate::schema::billable_metric)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct BillableMetricMetaRow {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BillableMetricId,
     pub name: String,
     pub code: String,
     pub aggregation_type: BillingMetricAggregateEnum,

--- a/modules/meteroid/crates/diesel-models/src/coupons.rs
+++ b/modules/meteroid/crates/diesel-models/src/coupons.rs
@@ -1,13 +1,12 @@
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{CouponId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
-use uuid::Uuid;
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
 #[diesel(table_name = crate::schema::coupon)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct CouponRow {
-    pub id: Uuid,
+    pub id: CouponId,
     pub code: String,
     pub description: String,
     pub tenant_id: TenantId,
@@ -22,15 +21,13 @@ pub struct CouponRow {
     pub last_redemption_at: Option<NaiveDateTime>,
     pub disabled: bool,
     pub archived_at: Option<NaiveDateTime>,
-    pub local_id: String,
 }
 
 #[derive(Debug, Default, Insertable)]
 #[diesel(table_name = crate::schema::coupon)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct CouponRowNew {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: CouponId,
     pub code: String,
     pub description: String,
     pub tenant_id: TenantId,
@@ -46,7 +43,7 @@ pub struct CouponRowNew {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id, tenant_id))]
 pub struct CouponRowPatch {
-    pub id: Uuid,
+    pub id: CouponId,
     pub tenant_id: TenantId,
     pub description: Option<String>,
     pub discount: Option<serde_json::Value>,
@@ -58,7 +55,7 @@ pub struct CouponRowPatch {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id, tenant_id))]
 pub struct CouponStatusRowPatch {
-    pub id: Uuid,
+    pub id: CouponId,
     pub tenant_id: TenantId,
     pub archived_at: Option<Option<NaiveDateTime>>,
     pub disabled: Option<bool>,

--- a/modules/meteroid/crates/diesel-models/src/credit_notes.rs
+++ b/modules/meteroid/crates/diesel-models/src/credit_notes.rs
@@ -2,14 +2,14 @@ use chrono::NaiveDateTime;
 use uuid::Uuid;
 
 use crate::enums::CreditNoteStatus;
-use common_domain::ids::{CustomerId, InvoiceId, TenantId};
+use common_domain::ids::{CreditNoteId, CustomerId, InvoiceId, TenantId};
 use diesel::{Identifiable, Queryable};
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(table_name = crate::schema::credit_note)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct CreditNoteRow {
-    pub id: Uuid,
+    pub id: CreditNoteId,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
     pub refunded_amount_cents: Option<i64>,
@@ -21,5 +21,4 @@ pub struct CreditNoteRow {
     pub tenant_id: TenantId,
     pub customer_id: CustomerId,
     pub status: CreditNoteStatus,
-    pub local_id: String,
 }

--- a/modules/meteroid/crates/diesel-models/src/customers.rs
+++ b/modules/meteroid/crates/diesel-models/src/customers.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
-use common_domain::ids::{CustomerId, TenantId};
+use common_domain::ids::{CustomerId, InvoicingEntityId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Clone, Debug, Identifiable, Queryable, Selectable)]
@@ -25,35 +25,8 @@ pub struct CustomerRow {
     pub currency: String,
     pub billing_address: Option<serde_json::Value>,
     pub shipping_address: Option<serde_json::Value>,
-    pub invoicing_entity_id: Uuid,
+    pub invoicing_entity_id: InvoicingEntityId,
     pub archived_by: Option<Uuid>,
-}
-
-#[derive(Clone, Debug, Identifiable, Queryable, Selectable)]
-#[diesel(table_name = crate::schema::customer)]
-#[diesel(check_for_backend(diesel::pg::Pg))]
-pub struct CustomerForDisplayRow {
-    pub id: CustomerId,
-    pub name: String,
-    pub created_at: NaiveDateTime,
-    pub created_by: Uuid,
-    pub updated_at: Option<NaiveDateTime>,
-    pub updated_by: Option<Uuid>,
-    pub archived_at: Option<NaiveDateTime>,
-    pub tenant_id: TenantId,
-    pub billing_config: serde_json::Value,
-    pub alias: Option<String>,
-    pub email: Option<String>,
-    pub invoicing_email: Option<String>,
-    pub phone: Option<String>,
-    pub balance_value_cents: i32,
-    pub currency: String,
-    pub billing_address: Option<serde_json::Value>,
-    pub shipping_address: Option<serde_json::Value>,
-    pub invoicing_entity_id: Uuid,
-    #[diesel(select_expression = crate::schema::invoicing_entity::local_id)]
-    #[diesel(select_expression_type = crate::schema::invoicing_entity::local_id)]
-    pub invoicing_entity_local_id: String,
 }
 
 #[derive(Clone, Debug, Queryable, Selectable)]
@@ -82,7 +55,7 @@ pub struct CustomerRowNew {
     pub currency: String,
     pub billing_address: Option<serde_json::Value>,
     pub shipping_address: Option<serde_json::Value>,
-    pub invoicing_entity_id: Uuid,
+    pub invoicing_entity_id: InvoicingEntityId,
     // for seed, else default to None
     pub created_at: Option<NaiveDateTime>,
 }
@@ -101,7 +74,7 @@ pub struct CustomerRowPatch {
     pub currency: Option<String>,
     pub billing_address: Option<serde_json::Value>,
     pub shipping_address: Option<serde_json::Value>,
-    pub invoicing_entity_id: Option<Uuid>,
+    pub invoicing_entity_id: Option<InvoicingEntityId>,
 }
 
 #[derive(Debug, AsChangeset)]
@@ -120,5 +93,5 @@ pub struct CustomerRowUpdate {
     pub updated_by: Uuid,
     pub billing_address: Option<serde_json::Value>,
     pub shipping_address: Option<serde_json::Value>,
-    pub invoicing_entity_id: Uuid,
+    pub invoicing_entity_id: InvoicingEntityId,
 }

--- a/modules/meteroid/crates/diesel-models/src/invoicing_entities.rs
+++ b/modules/meteroid/crates/diesel-models/src/invoicing_entities.rs
@@ -2,15 +2,14 @@ use uuid::Uuid;
 
 use crate::bank_accounts::BankAccountRow;
 use crate::connectors::ConnectorRow;
-use common_domain::ids::TenantId;
+use common_domain::ids::{InvoicingEntityId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Debug, Insertable, Queryable, Identifiable, Selectable)]
 #[diesel(table_name = crate::schema::invoicing_entity)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct InvoicingEntityRow {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: InvoicingEntityId,
     pub is_default: bool,
     pub legal_name: String,
     pub invoice_number_pattern: String,
@@ -39,7 +38,7 @@ pub struct InvoicingEntityRow {
 #[diesel(table_name = crate::schema::invoicing_entity)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct InvoicingEntityRowPatch {
-    pub id: Uuid,
+    pub id: InvoicingEntityId,
     pub legal_name: Option<String>,
     pub invoice_number_pattern: Option<String>,
     pub grace_period_hours: Option<i32>,
@@ -62,7 +61,7 @@ pub struct InvoicingEntityRowPatch {
 #[diesel(table_name = crate::schema::invoicing_entity)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct InvoicingEntityRowProvidersPatch {
-    pub id: Uuid,
+    pub id: InvoicingEntityId,
     pub cc_provider_id: Option<Uuid>,
     pub bank_account_id: Option<Uuid>,
 }

--- a/modules/meteroid/crates/diesel-models/src/outbox_event.rs
+++ b/modules/meteroid/crates/diesel-models/src/outbox_event.rs
@@ -1,17 +1,14 @@
-use uuid::Uuid;
-
-use common_domain::ids::TenantId;
+use common_domain::ids::{EventId, TenantId};
 use diesel::Insertable;
 
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::outbox_event)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct OutboxEventRowNew {
-    pub id: Uuid,
+    pub id: EventId,
     pub tenant_id: TenantId,
     pub aggregate_id: String,
     pub aggregate_type: String,
     pub event_type: String,
     pub payload: Option<serde_json::Value>,
-    pub local_id: String,
 }

--- a/modules/meteroid/crates/diesel-models/src/plan_versions.rs
+++ b/modules/meteroid/crates/diesel-models/src/plan_versions.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::enums::ActionAfterTrialEnum;
 
-use common_domain::ids::TenantId;
+use common_domain::ids::{PlanId, ProductFamilyId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
@@ -12,10 +12,10 @@ use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 pub struct PlanVersionRow {
     pub id: Uuid,
     pub is_draft_version: bool,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     pub version: i32,
     pub trial_duration_days: Option<i32>,
-    pub downgrade_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<PlanId>,
     pub tenant_id: TenantId,
     pub period_start_day: Option<i16>,
     pub net_terms: i32,
@@ -24,7 +24,7 @@ pub struct PlanVersionRow {
     pub billing_cycles: Option<i32>,
     pub created_at: NaiveDateTime,
     pub created_by: Uuid,
-    pub trialing_plan_id: Option<Uuid>,
+    pub trialing_plan_id: Option<PlanId>,
     pub action_after_trial: Option<ActionAfterTrialEnum>,
     pub trial_is_free: bool,
 }
@@ -35,17 +35,17 @@ pub struct PlanVersionRow {
 pub struct PlanVersionRowNew {
     pub id: Uuid,
     pub is_draft_version: bool,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     pub version: i32,
     pub trial_duration_days: Option<i32>,
-    pub downgrade_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<PlanId>,
     pub tenant_id: TenantId,
     pub period_start_day: Option<i16>,
     pub net_terms: i32,
     pub currency: String,
     pub billing_cycles: Option<i32>,
     pub created_by: Uuid,
-    pub trialing_plan_id: Option<Uuid>,
+    pub trialing_plan_id: Option<PlanId>,
     pub action_after_trial: Option<ActionAfterTrialEnum>,
     pub trial_is_free: bool,
 }
@@ -55,18 +55,15 @@ pub struct PlanVersionRowNew {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PlanVersionRowOverview {
     pub id: Uuid,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     #[diesel(select_expression = crate::schema::plan::name)]
     #[diesel(select_expression_type = crate::schema::plan::name)]
     pub plan_name: String,
-    #[diesel(select_expression = crate::schema::plan::local_id)]
-    #[diesel(select_expression_type = crate::schema::plan::local_id)]
-    pub local_id: String,
     pub version: i32,
     pub created_by: Uuid,
     pub trial_duration_days: Option<i32>,
-    pub downgrade_plan_id: Option<Uuid>,
-    pub trialing_plan_id: Option<Uuid>,
+    pub downgrade_plan_id: Option<PlanId>,
+    pub trialing_plan_id: Option<PlanId>,
     pub action_after_trial: Option<ActionAfterTrialEnum>,
     pub trial_is_free: bool,
     pub period_start_day: Option<i16>,
@@ -74,7 +71,7 @@ pub struct PlanVersionRowOverview {
     pub currency: String,
     #[diesel(select_expression = crate::schema::product_family::id)]
     #[diesel(select_expression_type = crate::schema::product_family::id)]
-    pub product_family_id: Uuid,
+    pub product_family_id: ProductFamilyId,
     #[diesel(select_expression = crate::schema::product_family::name)]
     #[diesel(select_expression_type = crate::schema::product_family::name)]
     pub product_family_name: String,
@@ -98,11 +95,11 @@ pub struct PlanVersionRowPatch {
 pub struct PlanVersionTrialRowPatch {
     pub id: Uuid,
     pub tenant_id: TenantId,
-    pub trialing_plan_id: Option<Option<Uuid>>,
+    pub trialing_plan_id: Option<Option<PlanId>>,
     pub action_after_trial: Option<Option<ActionAfterTrialEnum>>,
     pub trial_is_free: Option<bool>,
     pub trial_duration_days: Option<Option<i32>>,
-    pub downgrade_plan_id: Option<Option<Uuid>>,
+    pub downgrade_plan_id: Option<Option<PlanId>>,
 }
 
 #[derive(Debug, Clone)]

--- a/modules/meteroid/crates/diesel-models/src/plans.rs
+++ b/modules/meteroid/crates/diesel-models/src/plans.rs
@@ -3,14 +3,14 @@ use uuid::Uuid;
 
 use crate::enums::{PlanStatusEnum, PlanTypeEnum};
 use crate::plan_versions::PlanVersionRow;
-use common_domain::ids::TenantId;
+use common_domain::ids::{PlanId, ProductFamilyId, TenantId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
 #[diesel(table_name = crate::schema::plan)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PlanRow {
-    pub id: Uuid,
+    pub id: PlanId,
     pub name: String,
     pub description: Option<String>,
     pub created_at: NaiveDateTime,
@@ -18,8 +18,7 @@ pub struct PlanRow {
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub local_id: String,
+    pub product_family_id: ProductFamilyId,
     pub plan_type: PlanTypeEnum,
     pub status: PlanStatusEnum,
     pub active_version_id: Option<Uuid>,
@@ -30,28 +29,26 @@ pub struct PlanRow {
 #[diesel(table_name = crate::schema::plan)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PlanRowNew {
-    pub id: Uuid,
+    pub id: PlanId,
     pub name: String,
     pub description: Option<String>,
     pub created_by: Uuid,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub local_id: String,
+    pub product_family_id: ProductFamilyId,
     pub plan_type: PlanTypeEnum,
     pub status: PlanStatusEnum,
 }
 
 #[derive(Debug, Queryable)]
 pub struct PlanRowOverview {
-    pub id: Uuid,
+    pub id: PlanId,
     pub name: String,
     pub description: Option<String>,
     pub created_at: NaiveDateTime,
-    pub local_id: String,
     pub plan_type: PlanTypeEnum,
     pub status: PlanStatusEnum,
     pub product_family_name: String,
-    pub product_family_local_id: String,
+    pub product_family_id: ProductFamilyId,
     pub active_version: Option<PlanVersionRowInfo>,
     pub draft_version: Option<Uuid>,
     pub subscription_count: Option<i64>,
@@ -77,7 +74,7 @@ pub struct PlanWithVersionRow {
 #[diesel(check_for_backend(diesel::pg::Pg))]
 #[diesel(primary_key(id, tenant_id))]
 pub struct PlanRowPatch {
-    pub id: Uuid,
+    pub id: PlanId,
     pub tenant_id: TenantId,
     pub name: Option<String>,
     pub description: Option<Option<String>>,

--- a/modules/meteroid/crates/diesel-models/src/price_components.rs
+++ b/modules/meteroid/crates/diesel-models/src/price_components.rs
@@ -1,31 +1,30 @@
 use uuid::Uuid;
 
+use common_domain::ids::{BillableMetricId, PriceComponentId, ProductId};
 use diesel::{AsChangeset, Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, AsChangeset, Selectable)]
 #[diesel(table_name = crate::schema::price_component)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PriceComponentRow {
-    pub id: Uuid,
+    pub id: PriceComponentId,
     pub name: String,
     pub fee: serde_json::Value,
     pub plan_version_id: Uuid,
-    pub product_id: Option<Uuid>,
-    pub billable_metric_id: Option<Uuid>,
-    pub local_id: String,
+    pub product_id: Option<ProductId>,
+    pub billable_metric_id: Option<BillableMetricId>,
 }
 
 #[derive(Debug, Default, Insertable)]
 #[diesel(table_name = crate::schema::price_component)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct PriceComponentRowNew {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: PriceComponentId,
     pub name: String,
     pub fee: serde_json::Value,
     pub plan_version_id: Uuid,
-    pub product_id: Option<Uuid>,
-    pub billable_metric_id: Option<Uuid>,
+    pub product_id: Option<ProductId>,
+    pub billable_metric_id: Option<BillableMetricId>,
 }
 
 // the changeset one

--- a/modules/meteroid/crates/diesel-models/src/product_families.rs
+++ b/modules/meteroid/crates/diesel-models/src/product_families.rs
@@ -1,16 +1,14 @@
 use chrono::NaiveDateTime;
-use uuid::Uuid;
 
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, TenantId};
 use diesel::{Identifiable, Insertable, Queryable};
 
 #[derive(Queryable, Debug, Identifiable)]
 #[diesel(table_name = crate::schema::product_family)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProductFamilyRow {
-    pub id: Uuid,
+    pub id: ProductFamilyId,
     pub name: String,
-    pub local_id: String,
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
@@ -21,8 +19,7 @@ pub struct ProductFamilyRow {
 #[diesel(table_name = crate::schema::product_family)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProductFamilyRowNew {
-    pub id: Uuid,
+    pub id: ProductFamilyId,
     pub name: String,
-    pub local_id: String,
     pub tenant_id: TenantId,
 }

--- a/modules/meteroid/crates/diesel-models/src/products.rs
+++ b/modules/meteroid/crates/diesel-models/src/products.rs
@@ -1,14 +1,14 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, ProductId, TenantId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
 #[diesel(table_name = crate::schema::product)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProductRow {
-    pub id: Uuid,
+    pub id: ProductId,
     pub name: String,
     pub description: Option<String>,
     pub created_at: NaiveDateTime,
@@ -16,19 +16,17 @@ pub struct ProductRow {
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub local_id: String,
+    pub product_family_id: ProductFamilyId,
 }
 
 #[derive(Debug, Insertable)]
 #[diesel(table_name = crate::schema::product)]
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct ProductRowNew {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: ProductId,
     pub name: String,
     pub description: Option<String>,
     pub created_by: Uuid,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
+    pub product_family_id: ProductFamilyId,
 }

--- a/modules/meteroid/crates/diesel-models/src/query/add_ons.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/add_ons.rs
@@ -2,11 +2,8 @@ use crate::add_ons::{AddOnRow, AddOnRowNew, AddOnRowPatch};
 use crate::errors::IntoDbResult;
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
 use crate::{DbResult, PgConn};
-use common_domain::ids::TenantId;
-use diesel::{
-    debug_query, BoolExpressionMethods, ExpressionMethods, PgTextExpressionMethods, QueryDsl,
-    SelectableHelper,
-};
+use common_domain::ids::{AddOnId, TenantId};
+use diesel::{debug_query, ExpressionMethods, PgTextExpressionMethods, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use error_stack::ResultExt;
 use tap::TapFallible;
@@ -31,7 +28,7 @@ impl AddOnRow {
     pub async fn get_by_id(
         conn: &mut PgConn,
         tenant_id: TenantId,
-        id: uuid::Uuid,
+        id: AddOnId,
     ) -> DbResult<AddOnRow> {
         use crate::schema::add_on::dsl as ao_dsl;
 
@@ -61,11 +58,7 @@ impl AddOnRow {
             .into_boxed();
 
         if let Some(search) = search {
-            query = query.filter(
-                ao_dsl::name
-                    .ilike(format!("%{}%", search))
-                    .or(ao_dsl::local_id.ilike(format!("%{}%", search))),
-            );
+            query = query.filter(ao_dsl::name.ilike(format!("%{}%", search)));
         }
 
         let query = query.select(AddOnRow::as_select());
@@ -82,7 +75,7 @@ impl AddOnRow {
             .into_db_result()
     }
 
-    pub async fn delete(conn: &mut PgConn, id: uuid::Uuid, tenant_id: TenantId) -> DbResult<()> {
+    pub async fn delete(conn: &mut PgConn, id: AddOnId, tenant_id: TenantId) -> DbResult<()> {
         use crate::schema::add_on::dsl as ao_dsl;
 
         let query = diesel::delete(ao_dsl::add_on)
@@ -103,7 +96,7 @@ impl AddOnRow {
 
     pub async fn list_by_ids(
         conn: &mut PgConn,
-        ids: &[uuid::Uuid],
+        ids: &[AddOnId],
         tenant_id: TenantId,
     ) -> DbResult<Vec<AddOnRow>> {
         use crate::schema::add_on::dsl as ao_dsl;

--- a/modules/meteroid/crates/diesel-models/src/query/applied_coupons.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/applied_coupons.rs
@@ -4,7 +4,7 @@ use crate::applied_coupons::{
 use crate::errors::IntoDbResult;
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
 use crate::{DbResult, PgConn};
-use common_domain::ids::{SubscriptionId, TenantId};
+use common_domain::ids::{CouponId, SubscriptionId, TenantId};
 use diesel::{debug_query, ExpressionMethods, JoinOnDsl, QueryDsl, SelectableHelper};
 use diesel_async::RunQueryDsl;
 use error_stack::ResultExt;
@@ -28,7 +28,7 @@ impl AppliedCouponRowNew {
 }
 
 impl AppliedCouponRow {
-    pub async fn count_by_coupon_id(conn: &mut PgConn, param_coupon_id: &Uuid) -> DbResult<i64> {
+    pub async fn count_by_coupon_id(conn: &mut PgConn, param_coupon_id: CouponId) -> DbResult<i64> {
         use crate::schema::applied_coupon::dsl as ac;
 
         let query = ac::applied_coupon
@@ -90,9 +90,9 @@ impl AppliedCouponRow {
 }
 
 impl AppliedCouponForDisplayRow {
-    pub async fn list_by_coupon_local_id(
+    pub async fn list_by_coupon_id(
         conn: &mut PgConn,
-        param_coupon_id: &String,
+        param_coupon_id: CouponId,
         tenant_id: TenantId,
         pagination: PaginationRequest,
     ) -> DbResult<PaginatedVec<AppliedCouponForDisplayRow>> {
@@ -109,7 +109,7 @@ impl AppliedCouponForDisplayRow {
             .inner_join(s_dsl::subscription)
             .inner_join(pv_dsl::plan_version.on(s_dsl::plan_version_id.eq(pv_dsl::id)))
             .inner_join(p_dsl::plan.on(pv_dsl::plan_id.eq(p_dsl::id)))
-            .filter(cou_dsl::local_id.eq(param_coupon_id))
+            .filter(cou_dsl::id.eq(param_coupon_id))
             .filter(cou_dsl::tenant_id.eq(tenant_id))
             .order(ac_dsl::created_at.desc())
             .select(AppliedCouponForDisplayRow::as_select());

--- a/modules/meteroid/crates/diesel-models/src/query/bank_accounts.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/bank_accounts.rs
@@ -2,7 +2,7 @@ use crate::bank_accounts::{BankAccountRow, BankAccountRowNew, BankAccountRowPatc
 use crate::errors::IntoDbResult;
 
 use crate::{DbResult, PgConn};
-use common_domain::ids::TenantId;
+use common_domain::ids::{BankAccountId, TenantId};
 use diesel::{debug_query, ExpressionMethods, QueryDsl};
 use diesel_async::RunQueryDsl;
 use error_stack::ResultExt;
@@ -28,32 +28,12 @@ impl BankAccountRow {
     pub async fn get_by_id(
         conn: &mut PgConn,
         tenant_id: TenantId,
-        id: uuid::Uuid,
+        id: BankAccountId,
     ) -> DbResult<BankAccountRow> {
         use crate::schema::bank_account::dsl as ba_dsl;
 
         let query = ba_dsl::bank_account
             .filter(ba_dsl::id.eq(id))
-            .filter(ba_dsl::tenant_id.eq(tenant_id));
-
-        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query).to_string());
-
-        query
-            .first(conn)
-            .await
-            .attach_printable("Error while getting bank_account")
-            .into_db_result()
-    }
-
-    pub async fn get_by_local_id(
-        conn: &mut PgConn,
-        tenant_id: TenantId,
-        id: String,
-    ) -> DbResult<BankAccountRow> {
-        use crate::schema::bank_account::dsl as ba_dsl;
-
-        let query = ba_dsl::bank_account
-            .filter(ba_dsl::local_id.eq(id))
             .filter(ba_dsl::tenant_id.eq(tenant_id));
 
         log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query).to_string());
@@ -83,7 +63,11 @@ impl BankAccountRow {
             .into_db_result()
     }
 
-    pub async fn delete(conn: &mut PgConn, tenant_id: TenantId, id: uuid::Uuid) -> DbResult<usize> {
+    pub async fn delete(
+        conn: &mut PgConn,
+        tenant_id: TenantId,
+        id: BankAccountId,
+    ) -> DbResult<usize> {
         use crate::schema::bank_account::dsl as ba_dsl;
 
         let query = diesel::delete(ba_dsl::bank_account)
@@ -101,7 +85,7 @@ impl BankAccountRow {
 
     pub async fn list_by_ids(
         conn: &mut PgConn,
-        ids: &[uuid::Uuid],
+        ids: &[BankAccountId],
         tenant_id: TenantId,
     ) -> DbResult<Vec<BankAccountRow>> {
         use crate::schema::bank_account::dsl as ba_dsl;

--- a/modules/meteroid/crates/diesel-models/src/query/billable_metrics.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/billable_metrics.rs
@@ -4,7 +4,7 @@ use crate::errors::IntoDbResult;
 use crate::{DbResult, PgConn};
 
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
-use common_domain::ids::TenantId;
+use common_domain::ids::{BillableMetricId, ProductFamilyId, TenantId};
 use diesel::{debug_query, JoinOnDsl, SelectableHelper};
 use diesel::{ExpressionMethods, QueryDsl};
 use error_stack::ResultExt;
@@ -29,7 +29,7 @@ impl BillableMetricRowNew {
 impl BillableMetricRow {
     pub async fn find_by_id(
         conn: &mut PgConn,
-        param_billable_metric_id: uuid::Uuid,
+        param_billable_metric_id: BillableMetricId,
         param_tenant_id: TenantId,
     ) -> DbResult<BillableMetricRow> {
         use crate::schema::billable_metric::dsl::*;
@@ -49,7 +49,7 @@ impl BillableMetricRow {
 
     pub async fn get_by_ids(
         conn: &mut PgConn,
-        metric_ids: &[uuid::Uuid],
+        metric_ids: &[BillableMetricId],
         tenant_id_param: TenantId,
     ) -> DbResult<Vec<BillableMetricRow>> {
         use crate::schema::billable_metric::dsl::*;
@@ -68,7 +68,7 @@ impl BillableMetricRow {
         conn: &mut PgConn,
         param_tenant_id: TenantId,
         pagination: PaginationRequest,
-        param_product_family_local_id: Option<String>,
+        param_product_family_id: Option<ProductFamilyId>,
     ) -> DbResult<PaginatedVec<BillableMetricMetaRow>> {
         use crate::schema::billable_metric::dsl as bm_dsl;
         use crate::schema::product_family::dsl as pf_dsl;
@@ -78,8 +78,8 @@ impl BillableMetricRow {
             .filter(bm_dsl::tenant_id.eq(param_tenant_id))
             .into_boxed();
 
-        if let Some(id) = param_product_family_local_id {
-            query = query.filter(pf_dsl::local_id.eq(id));
+        if let Some(id) = param_product_family_id {
+            query = query.filter(pf_dsl::id.eq(id));
         }
 
         let query = query

--- a/modules/meteroid/crates/diesel-models/src/query/mod.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/mod.rs
@@ -30,8 +30,3 @@ pub mod subscriptions;
 pub mod tenants;
 pub mod users;
 pub mod webhooks;
-
-pub enum IdentityDb {
-    UUID(uuid::Uuid),
-    LOCAL(String),
-}

--- a/modules/meteroid/crates/diesel-models/src/query/plan_versions.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/plan_versions.rs
@@ -7,7 +7,7 @@ use crate::plan_versions::{
 use crate::{DbResult, PgConn};
 
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
-use common_domain::ids::TenantId;
+use common_domain::ids::{PlanId, TenantId};
 use diesel::prelude::{ExpressionMethods, QueryDsl};
 use diesel::{debug_query, JoinOnDsl, OptionalExtension, SelectableHelper};
 use error_stack::ResultExt;
@@ -52,7 +52,7 @@ impl PlanVersionRow {
 
     pub async fn find_latest_by_plan_id_and_tenant_id(
         conn: &mut PgConn,
-        plan_id: uuid::Uuid,
+        plan_id: PlanId,
         tenant_id: TenantId,
         is_draft: Option<bool>,
     ) -> DbResult<Option<PlanVersionRow>> {
@@ -84,7 +84,7 @@ impl PlanVersionRow {
 
     pub async fn get_latest_by_plan_id_and_tenant_id(
         conn: &mut PgConn,
-        plan_id: uuid::Uuid,
+        plan_id: PlanId,
         tenant_id: TenantId,
     ) -> DbResult<PlanVersionRow> {
         use crate::schema::plan_version::dsl as pv_dsl;
@@ -108,7 +108,7 @@ impl PlanVersionRow {
 
     pub async fn list_by_plan_id_and_tenant_id(
         conn: &mut PgConn,
-        plan_id: uuid::Uuid,
+        plan_id: PlanId,
         tenant_id: TenantId,
         pagination: PaginationRequest,
     ) -> DbResult<PaginatedVec<PlanVersionRow>> {
@@ -136,7 +136,7 @@ impl PlanVersionRow {
     pub async fn delete_others_draft(
         conn: &mut PgConn,
         excl_plan_version_id: uuid::Uuid,
-        plan_id: uuid::Uuid,
+        plan_id: PlanId,
         tenant_id: TenantId,
     ) -> DbResult<usize> {
         use crate::schema::plan_version::dsl as pv_dsl;

--- a/modules/meteroid/crates/diesel-models/src/query/price_components.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/price_components.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use crate::{DbResult, PgConn};
 
-use common_domain::ids::TenantId;
+use common_domain::ids::{PriceComponentId, TenantId};
 use diesel::{
     debug_query, ExpressionMethods, Insertable, OptionalExtension, QueryDsl, SelectableHelper,
 };
@@ -35,7 +35,7 @@ impl PriceComponentRow {
     pub async fn get_by_id(
         conn: &mut PgConn,
         param_tenant_id: TenantId,
-        param_id: uuid::Uuid,
+        param_id: PriceComponentId,
     ) -> DbResult<PriceComponentRow> {
         use crate::schema::plan_version::dsl as pv_dsl;
         use crate::schema::price_component::dsl as pc_dsl;
@@ -174,7 +174,7 @@ impl PriceComponentRow {
 
     pub async fn delete_by_id_and_tenant(
         conn: &mut PgConn,
-        component_id: uuid::Uuid,
+        component_id: PriceComponentId,
         tenant_id: TenantId,
     ) -> DbResult<()> {
         use crate::schema::plan_version::dsl as plan_version_dsl;

--- a/modules/meteroid/crates/diesel-models/src/query/product_families.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/product_families.rs
@@ -5,7 +5,7 @@ use crate::{DbResult, PgConn};
 
 use crate::extend::order::OrderByRequest;
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, TenantId};
 use diesel::{debug_query, ExpressionMethods, PgTextExpressionMethods, QueryDsl};
 use error_stack::ResultExt;
 
@@ -66,16 +66,16 @@ impl ProductFamilyRow {
             .into_db_result()
     }
 
-    pub async fn find_by_local_id_and_tenant_id(
+    pub async fn find_by_id(
         conn: &mut PgConn,
-        local_id: &str,
+        id: ProductFamilyId,
         tenant_id: TenantId,
     ) -> DbResult<ProductFamilyRow> {
         use crate::schema::product_family::dsl as pf_dsl;
         use diesel_async::RunQueryDsl;
 
         let query = pf_dsl::product_family
-            .filter(pf_dsl::local_id.eq(local_id))
+            .filter(pf_dsl::id.eq(id))
             .filter(pf_dsl::tenant_id.eq(tenant_id));
 
         log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query).to_string());
@@ -83,7 +83,7 @@ impl ProductFamilyRow {
         query
             .first(conn)
             .await
-            .attach_printable("Error while finding product family by local_id and tenant_id")
+            .attach_printable("Error while finding product family by id and tenant_id")
             .into_db_result()
     }
 }

--- a/modules/meteroid/crates/diesel-models/src/query/products.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/products.rs
@@ -5,12 +5,11 @@ use crate::{DbResult, PgConn};
 
 use crate::extend::order::OrderByRequest;
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, ProductId, TenantId};
 use diesel::{
     debug_query, ExpressionMethods, JoinOnDsl, PgTextExpressionMethods, QueryDsl, SelectableHelper,
 };
 use error_stack::ResultExt;
-use uuid::Uuid;
 
 impl ProductRowNew {
     pub async fn insert(&self, conn: &mut PgConn) -> DbResult<ProductRow> {
@@ -32,7 +31,7 @@ impl ProductRowNew {
 impl ProductRow {
     pub async fn find_by_id_and_tenant_id(
         conn: &mut PgConn,
-        id: Uuid,
+        id: ProductId,
         tenant_id: TenantId,
     ) -> DbResult<ProductRow> {
         use crate::schema::product::dsl as p_dsl;
@@ -54,7 +53,7 @@ impl ProductRow {
     pub async fn list(
         conn: &mut PgConn,
         tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> DbResult<PaginatedVec<ProductRow>> {
@@ -66,8 +65,8 @@ impl ProductRow {
             .filter(p_dsl::tenant_id.eq(tenant_id))
             .into_boxed();
 
-        if let Some(family_local_id) = family_local_id {
-            query = query.filter(pf_dsl::local_id.eq(family_local_id))
+        if let Some(family_id) = family_id {
+            query = query.filter(pf_dsl::id.eq(family_id))
         }
 
         let mut query = query.select(ProductRow::as_select());
@@ -98,7 +97,7 @@ impl ProductRow {
     pub async fn search(
         conn: &mut PgConn,
         tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         query: &str,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
@@ -112,8 +111,8 @@ impl ProductRow {
             .filter(p_dsl::name.ilike(format!("%{}%", query)))
             .into_boxed();
 
-        if let Some(family_local_id) = family_local_id {
-            query = query.filter(pf_dsl::local_id.eq(family_local_id))
+        if let Some(family_id) = family_id {
+            query = query.filter(pf_dsl::id.eq(family_id))
         }
 
         let mut query = query.select(ProductRow::as_select());

--- a/modules/meteroid/crates/diesel-models/src/query/slot_transactions.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/slot_transactions.rs
@@ -4,7 +4,7 @@ use crate::slot_transactions::SlotTransactionRow;
 use crate::{DbResult, PgConn};
 use chrono::NaiveDateTime;
 
-use common_domain::ids::SubscriptionId;
+use common_domain::ids::{PriceComponentId, SubscriptionId};
 use diesel::sql_types;
 use diesel::{debug_query, QueryableByName};
 use error_stack::ResultExt;
@@ -29,7 +29,7 @@ impl SlotTransactionRow {
         conn: &mut PgConn,
         subscription_uid: SubscriptionId,
         // TODO unit instead ?
-        price_component_uid: uuid::Uuid,
+        price_component_uid: PriceComponentId,
         at_ts: Option<NaiveDateTime>,
     ) -> DbResult<FetchTransactionResult> {
         use diesel_async::RunQueryDsl;

--- a/modules/meteroid/crates/diesel-models/src/query/subscriptions.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/subscriptions.rs
@@ -18,8 +18,7 @@ use crate::extend::cursor_pagination::{
     CursorPaginate, CursorPaginatedVec, CursorPaginationRequest,
 };
 use crate::extend::pagination::{Paginate, PaginatedVec, PaginationRequest};
-use crate::query::IdentityDb;
-use common_domain::ids::{BaseId, CustomerId, SubscriptionId, TenantId};
+use common_domain::ids::{BaseId, CustomerId, PlanId, SubscriptionId, TenantId};
 use error_stack::ResultExt;
 use uuid::Uuid;
 
@@ -191,7 +190,7 @@ impl SubscriptionRow {
         conn: &mut PgConn,
         tenant_id_param: TenantId,
         customer_id_opt: Option<CustomerId>,
-        plan_id_param_opt: Option<IdentityDb>,
+        plan_id_param_opt: Option<PlanId>,
         pagination: PaginationRequest,
     ) -> DbResult<PaginatedVec<SubscriptionForDisplayRow>> {
         use crate::schema::plan::dsl as p_dsl;
@@ -211,14 +210,7 @@ impl SubscriptionRow {
         }
 
         if let Some(plan_id_param) = plan_id_param_opt {
-            match plan_id_param {
-                IdentityDb::UUID(plan_id) => {
-                    query = query.filter(p_dsl::id.eq(plan_id));
-                }
-                IdentityDb::LOCAL(plan_local_id) => {
-                    query = query.filter(p_dsl::local_id.eq(plan_local_id));
-                }
-            }
+            query = query.filter(p_dsl::id.eq(plan_id_param));
         }
 
         //

--- a/modules/meteroid/crates/diesel-models/src/schema.rs
+++ b/modules/meteroid/crates/diesel-models/src/schema.rs
@@ -86,7 +86,6 @@ diesel::table! {
         tenant_id -> Uuid,
         created_at -> Timestamp,
         updated_at -> Timestamp,
-        local_id -> Text,
     }
 }
 
@@ -122,7 +121,6 @@ diesel::table! {
 
     bank_account (id) {
         id -> Uuid,
-        local_id -> Text,
         tenant_id -> Uuid,
         currency -> Text,
         country -> Text,
@@ -227,7 +225,6 @@ diesel::table! {
         tenant_id -> Uuid,
         product_family_id -> Uuid,
         product_id -> Nullable<Uuid>,
-        local_id -> Text,
     }
 }
 
@@ -265,7 +262,6 @@ diesel::table! {
         last_redemption_at -> Nullable<Timestamp>,
         disabled -> Bool,
         archived_at -> Nullable<Timestamp>,
-        local_id -> Text,
     }
 }
 
@@ -286,7 +282,6 @@ diesel::table! {
         tenant_id -> Uuid,
         customer_id -> Uuid,
         status -> CreditNoteStatus,
-        local_id -> Text,
     }
 }
 
@@ -441,7 +436,6 @@ diesel::table! {
 diesel::table! {
     invoicing_entity (id) {
         id -> Uuid,
-        local_id -> Text,
         is_default -> Bool,
         legal_name -> Text,
         invoice_number_pattern -> Text,
@@ -512,7 +506,6 @@ diesel::table! {
         event_type -> Text,
         payload -> Nullable<Jsonb>,
         created_at -> Timestamp,
-        local_id -> Text,
     }
 }
 
@@ -531,7 +524,6 @@ diesel::table! {
         archived_at -> Nullable<Timestamp>,
         tenant_id -> Uuid,
         product_family_id -> Uuid,
-        local_id -> Text,
         plan_type -> PlanTypeEnum,
         status -> PlanStatusEnum,
         active_version_id -> Nullable<Uuid>,
@@ -571,7 +563,6 @@ diesel::table! {
         plan_version_id -> Uuid,
         product_id -> Nullable<Uuid>,
         billable_metric_id -> Nullable<Uuid>,
-        local_id -> Text,
     }
 }
 
@@ -586,7 +577,6 @@ diesel::table! {
         archived_at -> Nullable<Timestamp>,
         tenant_id -> Uuid,
         product_family_id -> Uuid,
-        local_id -> Text,
     }
 }
 
@@ -594,7 +584,6 @@ diesel::table! {
     product_family (id) {
         id -> Uuid,
         name -> Text,
-        local_id -> Text,
         created_at -> Timestamp,
         updated_at -> Nullable<Timestamp>,
         archived_at -> Nullable<Timestamp>,

--- a/modules/meteroid/crates/diesel-models/src/slot_transactions.rs
+++ b/modules/meteroid/crates/diesel-models/src/slot_transactions.rs
@@ -1,7 +1,7 @@
 use chrono::NaiveDateTime;
 use uuid::Uuid;
 
-use common_domain::ids::SubscriptionId;
+use common_domain::ids::{PriceComponentId, SubscriptionId};
 use diesel::{Insertable, Queryable};
 
 #[derive(Queryable, Debug, Insertable)]
@@ -9,7 +9,7 @@ use diesel::{Insertable, Queryable};
 #[diesel(check_for_backend(diesel::pg::Pg))]
 pub struct SlotTransactionRow {
     pub id: Uuid,
-    pub price_component_id: Uuid,
+    pub price_component_id: PriceComponentId,
     pub subscription_id: SubscriptionId,
     pub delta: i32,
     pub prev_active_slots: i32,

--- a/modules/meteroid/crates/diesel-models/src/stats.rs
+++ b/modules/meteroid/crates/diesel-models/src/stats.rs
@@ -1,6 +1,6 @@
 use crate::enums::MrrMovementType;
 use chrono::{NaiveDate, NaiveDateTime};
-use common_domain::ids::{CustomerId, InvoiceId, SubscriptionId, TenantId};
+use common_domain::ids::{CustomerId, InvoiceId, PlanId, SubscriptionId, TenantId};
 use diesel::QueryableByName;
 use rust_decimal::Decimal;
 use uuid::Uuid;
@@ -184,7 +184,7 @@ pub struct TotalMrrByPlanRow {
     #[diesel(sql_type = diesel::sql_types::Date)]
     pub date: NaiveDate,
     #[diesel(sql_type = diesel::sql_types::Uuid)]
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     #[diesel(sql_type = diesel::sql_types::Text)]
     pub plan_name: String,
     #[diesel(sql_type = diesel::sql_types::BigInt)]

--- a/modules/meteroid/crates/diesel-models/src/subscription_add_ons.rs
+++ b/modules/meteroid/crates/diesel-models/src/subscription_add_ons.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 use uuid::Uuid;
 
 use crate::enums::SubscriptionFeeBillingPeriod;
-use common_domain::ids::SubscriptionId;
+use common_domain::ids::{AddOnId, SubscriptionId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
@@ -12,7 +12,7 @@ pub struct SubscriptionAddOnRow {
     pub id: Uuid,
     pub name: String,
     pub subscription_id: SubscriptionId,
-    pub add_on_id: Uuid,
+    pub add_on_id: AddOnId,
     pub period: SubscriptionFeeBillingPeriod,
     pub fee: serde_json::Value,
     pub created_at: NaiveDateTime,
@@ -25,7 +25,7 @@ pub struct SubscriptionAddOnRowNew {
     pub id: Uuid,
     pub name: String,
     pub subscription_id: SubscriptionId,
-    pub add_on_id: Uuid,
+    pub add_on_id: AddOnId,
     pub period: SubscriptionFeeBillingPeriod,
     pub fee: serde_json::Value,
 }

--- a/modules/meteroid/crates/diesel-models/src/subscription_components.rs
+++ b/modules/meteroid/crates/diesel-models/src/subscription_components.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 use crate::enums::SubscriptionFeeBillingPeriod;
-use common_domain::ids::SubscriptionId;
+use common_domain::ids::{PriceComponentId, ProductId, SubscriptionId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 
 #[derive(Queryable, Debug, Identifiable, Selectable)]
@@ -11,8 +11,8 @@ pub struct SubscriptionComponentRow {
     pub id: Uuid,
     pub name: String,
     pub subscription_id: SubscriptionId,
-    pub price_component_id: Option<Uuid>,
-    pub product_id: Option<Uuid>,
+    pub price_component_id: Option<PriceComponentId>,
+    pub product_id: Option<ProductId>,
     pub period: SubscriptionFeeBillingPeriod,
     // pub mrr_value: Option<Decimal>,
     pub fee: serde_json::Value,
@@ -24,8 +24,8 @@ pub struct SubscriptionComponentRowNew {
     pub id: Uuid,
     pub name: String,
     pub subscription_id: SubscriptionId,
-    pub price_component_id: Option<Uuid>,
-    pub product_id: Option<Uuid>,
+    pub price_component_id: Option<PriceComponentId>,
+    pub product_id: Option<ProductId>,
     pub period: SubscriptionFeeBillingPeriod,
     // pub mrr_value: Option<Decimal>,
     pub fee: serde_json::Value,

--- a/modules/meteroid/crates/diesel-models/src/subscriptions.rs
+++ b/modules/meteroid/crates/diesel-models/src/subscriptions.rs
@@ -6,7 +6,7 @@ use chrono::NaiveDateTime;
 use uuid::Uuid;
 
 use crate::enums::BillingPeriodEnum;
-use common_domain::ids::{CustomerId, SubscriptionId, TenantId};
+use common_domain::ids::{CustomerId, PlanId, SubscriptionId, TenantId};
 use diesel::{Identifiable, Insertable, Queryable, Selectable};
 use rust_decimal::Decimal;
 
@@ -86,7 +86,7 @@ pub struct SubscriptionForDisplayRow {
     pub plan_name: String,
     #[diesel(select_expression = plan::id)]
     #[diesel(select_expression_type = plan::id)]
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
 }
 
 #[derive(Debug, Queryable, Selectable)]
@@ -112,7 +112,7 @@ mod subscription_invoice_candidate {
 
     use chrono::{NaiveDate, NaiveDateTime};
 
-    use common_domain::ids::{CustomerId, SubscriptionId, TenantId};
+    use common_domain::ids::{CustomerId, PlanId, SubscriptionId, TenantId};
     use diesel::{Queryable, Selectable};
     use uuid::Uuid;
 
@@ -136,15 +136,12 @@ mod subscription_invoice_candidate {
     #[diesel(table_name = crate::schema::plan_version)]
     #[diesel(check_for_backend(diesel::pg::Pg))]
     pub struct PlanVersionEmbedRow {
-        pub plan_id: Uuid,
+        pub plan_id: PlanId,
         pub currency: String,
         pub net_terms: i32,
         pub version: i32,
         #[diesel(select_expression = crate::schema::plan::name)]
         #[diesel(select_expression_type = crate::schema::plan::name)]
         pub plan_name: String,
-        #[diesel(select_expression = crate::schema::plan::local_id)]
-        #[diesel(select_expression_type = crate::schema::plan::local_id)]
-        pub plan_local_id: String,
     }
 }

--- a/modules/meteroid/crates/meteroid-store/src/compute/clients/slots.rs
+++ b/modules/meteroid/crates/meteroid-store/src/compute/clients/slots.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 use crate::compute::errors::ComputeError;
 
 use crate::repositories::subscriptions::SubscriptionSlotsInterface;
-use common_domain::ids::{SubscriptionId, TenantId};
+use common_domain::ids::{PriceComponentId, SubscriptionId, TenantId};
 use error_stack::{Result, ResultExt};
 
 #[async_trait::async_trait]
@@ -14,7 +14,7 @@ pub trait SlotClient {
         &self,
         tenant_id: TenantId,
         subscription_id: SubscriptionId,
-        component_id: &Uuid,
+        component_id: PriceComponentId,
         // slot_unit: &String,
         invoice_date: &NaiveDate,
     ) -> Result<u32, ComputeError>;
@@ -26,14 +26,14 @@ impl SlotClient for crate::Store {
         &self,
         tenant_id: TenantId,
         subscription_id: SubscriptionId,
-        component_id: &Uuid,
+        component_id: PriceComponentId,
         invoice_date: &NaiveDate,
     ) -> Result<u32, ComputeError> {
         let res = self
             .get_current_slots_value(
                 tenant_id,
                 subscription_id,
-                *component_id,
+                component_id,
                 invoice_date.clone().and_hms_opt(0, 0, 0),
             )
             .await
@@ -53,7 +53,7 @@ impl SlotClient for MockSlotClient {
         &self,
         _tenant_id: TenantId,
         _subscription_id: SubscriptionId,
-        component_id: &Uuid,
+        component_id: PriceComponentId,
         invoice_date: &NaiveDate,
     ) -> Result<u32, ComputeError> {
         match self.data.get(&(*component_id, *invoice_date)) {

--- a/modules/meteroid/crates/meteroid-store/src/compute/clients/usage.rs
+++ b/modules/meteroid/crates/meteroid-store/src/compute/clients/usage.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use crate::compute::errors::ComputeError;
 use crate::domain::{BillableMetric, Period};
 use chrono::NaiveDate;
-use common_domain::ids::CustomerId;
+use common_domain::ids::{BillableMetricId, CustomerId, TenantId};
 use rust_decimal::Decimal;
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct UsageData {
@@ -42,13 +41,13 @@ pub struct Metadata {
 pub trait UsageClient: Send + Sync {
     async fn register_meter(
         &self,
-        tenant_id: &Uuid,
+        tenant_id: TenantId,
         metric: &BillableMetric,
     ) -> Result<Vec<Metadata>, ComputeError>;
 
     async fn fetch_usage(
         &self,
-        tenant_id: &Uuid,
+        tenant_id: TenantId,
         customer_id: CustomerId,
         customer_alias: &Option<String>,
         metric: &BillableMetric,
@@ -58,7 +57,7 @@ pub trait UsageClient: Send + Sync {
 
 #[derive(Eq, Hash, PartialEq)]
 pub struct MockUsageDataParams {
-    metric_id: Uuid,
+    metric_id: BillableMetricId,
     invoice_date: NaiveDate,
 }
 
@@ -70,7 +69,7 @@ pub struct MockUsageClient {
 impl UsageClient for MockUsageClient {
     async fn register_meter(
         &self,
-        _tenant_id: &Uuid,
+        _tenant_id: TenantId,
         _metric: &BillableMetric,
     ) -> Result<Vec<Metadata>, ComputeError> {
         Ok(vec![])
@@ -78,7 +77,7 @@ impl UsageClient for MockUsageClient {
 
     async fn fetch_usage(
         &self,
-        _tenant_id: &Uuid,
+        _tenant_id: TenantId,
         _customer_local_id: CustomerId,
         _customer_alias: &Option<String>,
         metric: &BillableMetric,

--- a/modules/meteroid/crates/meteroid-store/src/domain/add_ons.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/add_ons.rs
@@ -1,16 +1,13 @@
 use crate::domain::FeeType;
 use crate::errors::{StoreError, StoreErrorReport};
-use crate::utils::local_id::{IdType, LocalId};
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{AddOnId, BaseId, TenantId};
 use diesel_models::add_ons::{AddOnRow, AddOnRowNew, AddOnRowPatch};
 use error_stack::Report;
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct AddOn {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: AddOnId,
     pub name: String,
     pub fee: FeeType,
     pub tenant_id: TenantId,
@@ -27,7 +24,6 @@ impl TryInto<AddOn> for AddOnRow {
         Ok(AddOn {
             id: self.id,
             name: self.name,
-            local_id: self.local_id,
             fee,
             tenant_id: self.tenant_id,
             created_at: self.created_at,
@@ -50,8 +46,7 @@ impl TryInto<AddOnRowNew> for AddOnNew {
         let json_fee = (&self.fee).try_into()?;
 
         Ok(AddOnRowNew {
-            id: Uuid::now_v7(),
-            local_id: LocalId::generate_for(IdType::AddOn),
+            id: AddOnId::new(),
             tenant_id: self.tenant_id,
             name: self.name,
             fee: json_fee,
@@ -61,7 +56,7 @@ impl TryInto<AddOnRowNew> for AddOnNew {
 
 #[derive(Debug, Clone)]
 pub struct AddOnPatch {
-    pub id: Uuid,
+    pub id: AddOnId,
     pub tenant_id: TenantId,
     pub name: Option<String>,
     pub fee: Option<FeeType>,

--- a/modules/meteroid/crates/meteroid-store/src/domain/bank_accounts.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/bank_accounts.rs
@@ -1,5 +1,5 @@
 pub use crate::domain::enums::BankAccountFormat;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BankAccountId, TenantId};
 use diesel_models::bank_accounts::{BankAccountRow, BankAccountRowNew, BankAccountRowPatch};
 use o2o::o2o;
 use uuid::Uuid;
@@ -7,8 +7,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug, o2o)]
 #[from_owned(BankAccountRow)]
 pub struct BankAccount {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub currency: String,
     pub country: String,
@@ -21,8 +20,7 @@ pub struct BankAccount {
 #[derive(Clone, Debug, o2o)]
 #[owned_into(BankAccountRowNew)]
 pub struct BankAccountNew {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub created_by: Uuid,
     pub currency: String,
@@ -36,7 +34,7 @@ pub struct BankAccountNew {
 #[derive(Clone, Debug, o2o)]
 #[owned_into(BankAccountRowPatch)]
 pub struct BankAccountPatch {
-    pub id: Uuid,
+    pub id: BankAccountId,
     pub tenant_id: TenantId,
     pub currency: Option<String>,
     pub country: Option<String>,

--- a/modules/meteroid/crates/meteroid-store/src/domain/billable_metrics.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/billable_metrics.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDateTime;
 use std::collections::HashMap;
 
 use crate::json_value_serde;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BillableMetricId, ProductFamilyId, ProductId, TenantId};
 use diesel_models::billable_metrics::{BillableMetricMetaRow, BillableMetricRow};
 use o2o::o2o;
 use serde::{Deserialize, Serialize};
@@ -13,8 +13,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug, o2o)]
 #[try_map_owned(BillableMetricRow, StoreErrorReport)]
 pub struct BillableMetric {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BillableMetricId,
     pub name: String,
     pub description: Option<String>,
     pub code: String,
@@ -32,8 +31,8 @@ pub struct BillableMetric {
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
-    pub product_id: Option<Uuid>,
+    pub product_family_id: ProductFamilyId,
+    pub product_id: Option<ProductId>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -71,16 +70,15 @@ pub struct BillableMetricNew {
     pub usage_group_key: Option<String>,
     pub created_by: Uuid,
     pub tenant_id: TenantId,
-    pub family_local_id: String,
-    pub product_id: Option<Uuid>,
+    pub product_family_id: ProductFamilyId,
+    pub product_id: Option<ProductId>,
 }
 
 #[derive(Clone, Debug, o2o)]
 #[from_owned(BillableMetricMetaRow)]
 #[owned_into(BillableMetricMetaRow)]
 pub struct BillableMetricMeta {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: BillableMetricId,
     pub name: String,
     pub code: String,
     #[map(~.into())]

--- a/modules/meteroid/crates/meteroid-store/src/domain/coupons.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/coupons.rs
@@ -1,8 +1,7 @@
 use crate::errors::{StoreError, StoreErrorReport};
 use crate::json_value_serde;
-use crate::utils::local_id::{IdType, LocalId};
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BaseId, CouponId, TenantId};
 use diesel_models::coupons::{
     CouponFilter as CouponFilterDb, CouponRow, CouponRowNew, CouponRowPatch, CouponStatusRowPatch,
 };
@@ -10,12 +9,10 @@ use error_stack::Report;
 use o2o::o2o;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct Coupon {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: CouponId,
     pub code: String,
     pub description: String,
     pub tenant_id: TenantId,
@@ -75,7 +72,6 @@ impl TryInto<Coupon> for CouponRow {
 
         Ok(Coupon {
             id: self.id,
-            local_id: self.local_id,
             code: self.code,
             description: self.description,
             tenant_id: self.tenant_id,
@@ -113,8 +109,7 @@ impl TryInto<CouponRowNew> for CouponNew {
         let json_discount: serde_json::Value = (&self.discount).try_into()?;
 
         Ok(CouponRowNew {
-            id: Uuid::now_v7(),
-            local_id: LocalId::generate_for(IdType::Coupon),
+            id: CouponId::new(),
             code: self.code,
             description: self.description,
             tenant_id: self.tenant_id,
@@ -129,7 +124,7 @@ impl TryInto<CouponRowNew> for CouponNew {
 
 #[derive(Debug, Clone)]
 pub struct CouponPatch {
-    pub id: Uuid,
+    pub id: CouponId,
     pub tenant_id: TenantId,
     pub description: Option<String>,
     pub discount: Option<CouponDiscount>,
@@ -139,7 +134,7 @@ pub struct CouponPatch {
 #[derive(Clone, Debug, o2o)]
 #[owned_into(CouponStatusRowPatch)]
 pub struct CouponStatusPatch {
-    pub id: Uuid,
+    pub id: CouponId,
     pub tenant_id: TenantId,
     pub archived_at: Option<Option<NaiveDateTime>>,
     pub disabled: Option<bool>,

--- a/modules/meteroid/crates/meteroid-store/src/domain/invoice_lines.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/invoice_lines.rs
@@ -1,6 +1,6 @@
+use common_domain::ids::{BillableMetricId, PriceComponentId, ProductId};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 #[derive(PartialEq, Debug, Deserialize, Serialize, Eq, Clone)]
 pub struct LineItem {
@@ -19,9 +19,9 @@ pub struct LineItem {
 
     pub is_prorated: bool,
 
-    pub price_component_id: Option<Uuid>, // local_id ?
-    pub product_id: Option<Uuid>,
-    pub metric_id: Option<Uuid>,
+    pub price_component_id: Option<PriceComponentId>, // local_id ?
+    pub product_id: Option<ProductId>,
+    pub metric_id: Option<BillableMetricId>,
 
     pub description: Option<String>,
 }

--- a/modules/meteroid/crates/meteroid-store/src/domain/invoices.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/invoices.rs
@@ -5,7 +5,9 @@ use crate::domain::{Address, AppliedCouponDetailed, Customer, PlanVersionOvervie
 use crate::errors::{StoreError, StoreErrorReport};
 use crate::utils::decimals::ToSubunit;
 use chrono::{NaiveDate, NaiveDateTime};
-use common_domain::ids::{BaseId, CustomerId, InvoiceId, SubscriptionId, TenantId};
+use common_domain::ids::{
+    BaseId, CustomerId, InvoiceId, InvoicingEntityId, SubscriptionId, TenantId,
+};
 use diesel_models::invoices::DetailedInvoiceRow;
 use diesel_models::invoices::InvoiceRow;
 use diesel_models::invoices::InvoiceRowLinesPatch;
@@ -183,7 +185,7 @@ pub struct InlineCustomer {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct InlineInvoicingEntity {
-    pub id: Uuid,
+    pub id: InvoicingEntityId,
     pub legal_name: String,
     pub vat_number: Option<String>,
     pub address: Address,

--- a/modules/meteroid/crates/meteroid-store/src/domain/invoicing_entities.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/invoicing_entities.rs
@@ -1,6 +1,6 @@
 use crate::domain::connectors::ConnectorMeta;
 use crate::domain::{Address, BankAccount};
-use common_domain::ids::TenantId;
+use common_domain::ids::{InvoicingEntityId, TenantId};
 use diesel_models::invoicing_entities::{
     InvoicingEntityProvidersRow, InvoicingEntityRow, InvoicingEntityRowPatch,
     InvoicingEntityRowProvidersPatch,
@@ -12,8 +12,7 @@ use uuid::Uuid;
 #[derive(Clone, Debug, Serialize, Deserialize, o2o)]
 #[map_owned(InvoicingEntityRow)]
 pub struct InvoicingEntity {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: InvoicingEntityId,
     pub is_default: bool,
 
     pub legal_name: String,
@@ -83,7 +82,7 @@ pub struct InvoicingEntityNew {
 #[owned_into(InvoicingEntityRowPatch)]
 #[ghosts(accounting_currency: {None})]
 pub struct InvoicingEntityPatch {
-    pub id: Uuid,
+    pub id: InvoicingEntityId,
     pub legal_name: Option<String>,
     pub invoice_number_pattern: Option<String>,
     pub grace_period_hours: Option<i32>,
@@ -104,7 +103,7 @@ pub struct InvoicingEntityPatch {
 #[derive(Clone, Debug, o2o, Default)]
 #[owned_into(InvoicingEntityRowProvidersPatch)]
 pub struct InvoicingEntityProvidersPatch {
-    pub id: Uuid,
+    pub id: InvoicingEntityId,
     pub cc_provider_id: Option<Uuid>,
     pub bank_account_id: Option<Uuid>,
 }

--- a/modules/meteroid/crates/meteroid-store/src/domain/mod.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/mod.rs
@@ -2,12 +2,10 @@ pub use api_tokens::*;
 pub use bank_accounts::*;
 pub use billable_metrics::*;
 pub use customers::*;
-use diesel_models::query::IdentityDb;
 pub use invoice_lines::*;
 pub use invoices::*;
 pub use invoicing_entities::*;
 pub use misc::*;
-use o2o::o2o;
 pub use organizations::*;
 pub use plans::*;
 pub use price_components::*;
@@ -19,7 +17,6 @@ pub use subscription_components::*;
 pub use subscription_coupons::*;
 pub use subscriptions::*;
 pub use tenants::*;
-use uuid::Uuid;
 
 pub mod customers;
 pub mod invoices;
@@ -53,10 +50,3 @@ pub mod subscription_coupons;
 pub mod subscriptions;
 pub mod users;
 pub mod webhooks;
-
-#[derive(Debug, Clone, PartialEq, Eq, o2o)]
-#[owned_into(IdentityDb)]
-pub enum Identity {
-    UUID(Uuid),
-    LOCAL(String),
-}

--- a/modules/meteroid/crates/meteroid-store/src/domain/outbox_event.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/outbox_event.rs
@@ -1,10 +1,11 @@
 use crate::domain::enums::{BillingPeriodEnum, InvoiceStatusEnum};
 use crate::domain::{Address, Customer, DetailedInvoice, ShippingAddress, Subscription};
 use crate::errors::{StoreError, StoreErrorReport};
-use crate::utils::local_id::{IdType, LocalId};
 use crate::StoreResult;
 use chrono::{NaiveDate, NaiveDateTime};
-use common_domain::ids::{BaseId, CustomerId, InvoiceId, SubscriptionId, TenantId};
+use common_domain::ids::{
+    BaseId, CustomerId, EventId, InvoiceId, PlanId, SubscriptionId, TenantId,
+};
 use diesel_models::outbox_event::OutboxEventRowNew;
 use error_stack::Report;
 use o2o::o2o;
@@ -112,8 +113,7 @@ impl TryInto<OutboxEventRowNew> for OutboxEvent {
     type Error = StoreErrorReport;
     fn try_into(self) -> Result<OutboxEventRowNew, Self::Error> {
         Ok(OutboxEventRowNew {
-            id: Uuid::now_v7(),
-            local_id: LocalId::generate_for(IdType::Event),
+            id: EventId::new(),
             tenant_id: self.tenant_id,
             aggregate_id: self.aggregate_id.to_string(),
             aggregate_type: self.event_type.aggregate_type(),
@@ -160,7 +160,7 @@ pub struct SubscriptionEvent {
     pub billing_start_date: NaiveDate,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_end_date: Option<NaiveDate>,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     pub plan_name: String,
     pub plan_version_id: Uuid,
     pub version: u32,

--- a/modules/meteroid/crates/meteroid-store/src/domain/product_families.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/product_families.rs
@@ -1,19 +1,15 @@
-use crate::utils::local_id::IdType;
-use crate::utils::local_id::LocalId;
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BaseId, ProductFamilyId, TenantId};
 use diesel_models::product_families::ProductFamilyRow;
 use diesel_models::product_families::ProductFamilyRowNew;
 use o2o::o2o;
-use uuid::Uuid;
 
 #[derive(Clone, Debug, o2o)]
 #[from_owned(ProductFamilyRow)]
 #[owned_into(ProductFamilyRow)]
 pub struct ProductFamily {
-    pub id: Uuid,
+    pub id: ProductFamilyId,
     pub name: String,
-    pub local_id: String,
     pub created_at: NaiveDateTime,
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
@@ -22,7 +18,7 @@ pub struct ProductFamily {
 
 #[derive(Clone, Debug, o2o)]
 #[owned_into(ProductFamilyRowNew)]
-#[ghosts(id: {uuid::Uuid::now_v7()}, local_id: {LocalId::generate_for(IdType::ProductFamily) })]
+#[ghosts(id: {ProductFamilyId::new() })]
 pub struct ProductFamilyNew {
     pub name: String,
     pub tenant_id: TenantId,

--- a/modules/meteroid/crates/meteroid-store/src/domain/products.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/products.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDateTime;
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, ProductId, TenantId};
 use diesel_models::products::ProductRow;
 use o2o::o2o;
 use uuid::Uuid;
@@ -8,8 +8,7 @@ use uuid::Uuid;
 #[from_owned(ProductRow)]
 #[owned_into(ProductRow)]
 pub struct Product {
-    pub id: Uuid,
-    pub local_id: String,
+    pub id: ProductId,
     pub name: String,
     pub description: Option<String>,
     pub created_at: NaiveDateTime,
@@ -17,7 +16,7 @@ pub struct Product {
     pub updated_at: Option<NaiveDateTime>,
     pub archived_at: Option<NaiveDateTime>,
     pub tenant_id: TenantId,
-    pub product_family_id: Uuid,
+    pub product_family_id: ProductFamilyId,
 }
 
 #[derive(Clone, Debug)]
@@ -26,5 +25,5 @@ pub struct ProductNew {
     pub description: Option<String>,
     pub created_by: Uuid,
     pub tenant_id: TenantId,
-    pub family_local_id: String,
+    pub family_id: ProductFamilyId,
 }

--- a/modules/meteroid/crates/meteroid-store/src/domain/stats.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/stats.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use common_domain::ids::{CustomerId, TenantId};
+use common_domain::ids::{CustomerId, PlanId, TenantId};
 use uuid::Uuid;
 
 pub enum TrendScope {
@@ -94,7 +94,7 @@ pub struct MrrChartSeries {
 }
 
 pub struct PlanBrief {
-    pub id: Uuid,
+    pub id: PlanId,
     pub name: String,
 }
 

--- a/modules/meteroid/crates/meteroid-store/src/domain/subscription_add_ons.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/subscription_add_ons.rs
@@ -2,7 +2,7 @@ use crate::domain::enums::{BillingPeriodEnum, SubscriptionFeeBillingPeriod};
 use crate::domain::{SubscriptionFee, SubscriptionFeeInterface};
 use crate::errors::StoreErrorReport;
 use chrono::NaiveDateTime;
-use common_domain::ids::SubscriptionId;
+use common_domain::ids::{AddOnId, PriceComponentId, ProductId, SubscriptionId};
 use diesel_models::subscription_add_ons::{SubscriptionAddOnRow, SubscriptionAddOnRowNew};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -11,7 +11,7 @@ use uuid::Uuid;
 pub struct SubscriptionAddOn {
     pub id: Uuid,
     pub subscription_id: SubscriptionId,
-    pub add_on_id: Uuid,
+    pub add_on_id: AddOnId,
     pub name: String,
     pub period: SubscriptionFeeBillingPeriod,
     pub fee: SubscriptionFee,
@@ -20,12 +20,12 @@ pub struct SubscriptionAddOn {
 
 impl SubscriptionFeeInterface for SubscriptionAddOn {
     #[inline]
-    fn price_component_id(&self) -> Option<Uuid> {
+    fn price_component_id(&self) -> Option<PriceComponentId> {
         None
     }
 
     #[inline]
-    fn product_id(&self) -> Option<Uuid> {
+    fn product_id(&self) -> Option<ProductId> {
         None
     }
 
@@ -70,7 +70,7 @@ impl TryInto<SubscriptionAddOn> for SubscriptionAddOnRow {
 
 #[derive(Clone, Debug)]
 pub struct SubscriptionAddOnNewInternal {
-    pub add_on_id: Uuid,
+    pub add_on_id: AddOnId,
     pub name: String,
     pub period: SubscriptionFeeBillingPeriod,
     pub fee: SubscriptionFee,
@@ -122,7 +122,7 @@ pub enum SubscriptionAddOnCustomization {
 
 #[derive(Debug, Clone)]
 pub struct CreateSubscriptionAddOn {
-    pub add_on_id: Uuid,
+    pub add_on_id: AddOnId,
     pub customization: SubscriptionAddOnCustomization,
 }
 

--- a/modules/meteroid/crates/meteroid-store/src/domain/subscription_coupons.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/subscription_coupons.rs
@@ -1,7 +1,7 @@
 use crate::domain::coupons::{Coupon, CouponDiscount};
 use crate::errors::StoreErrorReport;
 use chrono::NaiveDateTime;
-use common_domain::ids::{CustomerId, SubscriptionId};
+use common_domain::ids::{CouponId, CustomerId, PlanId, SubscriptionId};
 use diesel_models::applied_coupons::{
     AppliedCouponDetailedRow, AppliedCouponForDisplayRow, AppliedCouponRow,
 };
@@ -12,7 +12,7 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone)]
 pub struct CreateSubscriptionCoupon {
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
 }
 
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ pub struct CreateSubscriptionCoupons {
 #[owned_into(AppliedCouponRow)]
 pub struct AppliedCoupon {
     pub id: Uuid,
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
     pub customer_id: CustomerId,
     pub subscription_id: SubscriptionId,
     pub is_active: bool,
@@ -39,12 +39,11 @@ pub struct AppliedCoupon {
 #[from_owned(AppliedCouponForDisplayRow)]
 pub struct AppliedCouponForDisplay {
     pub id: Uuid,
-    pub coupon_id: Uuid,
+    pub coupon_id: CouponId,
     pub customer_id: CustomerId,
     pub customer_name: String,
     pub subscription_id: SubscriptionId,
-    pub plan_id: Uuid,
-    pub plan_local_id: String,
+    pub plan_id: PlanId,
     pub plan_version: i32,
     pub plan_name: String,
     pub is_active: bool,

--- a/modules/meteroid/crates/meteroid-store/src/domain/subscriptions.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/subscriptions.rs
@@ -6,7 +6,7 @@ use crate::domain::{
     AppliedCouponDetailed, BillableMetric, CreateSubscriptionComponents, CreateSubscriptionCoupons,
     Schedule, SubscriptionComponent,
 };
-use common_domain::ids::{BaseId, CustomerId, SubscriptionId, TenantId};
+use common_domain::ids::{BaseId, CustomerId, PlanId, SubscriptionId, TenantId};
 use diesel_models::subscriptions::SubscriptionRowNew;
 use diesel_models::subscriptions::{
     SubscriptionForDisplayRow, SubscriptionInvoiceCandidateRow, SubscriptionRow,
@@ -51,7 +51,7 @@ pub struct Subscription {
     pub trial_start_date: Option<NaiveDate>,
     pub billing_start_date: NaiveDate,
     pub billing_end_date: Option<NaiveDate>,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     pub plan_name: String,
     pub plan_version_id: Uuid,
     pub version: u32,
@@ -178,7 +178,7 @@ pub struct SubscriptionDetails {
     //
     pub version: u32,
     pub plan_name: String,
-    pub plan_id: Uuid,
+    pub plan_id: PlanId,
     pub customer_name: String,
     pub canceled_at: Option<chrono::NaiveDateTime>,
 

--- a/modules/meteroid/crates/meteroid-store/src/repositories/add_ons.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/add_ons.rs
@@ -2,10 +2,9 @@ use crate::domain::add_ons::{AddOn, AddOnNew, AddOnPatch};
 use crate::domain::{PaginatedVec, PaginationRequest};
 use crate::errors::StoreError;
 use crate::{Store, StoreResult};
-use common_domain::ids::TenantId;
+use common_domain::ids::{AddOnId, TenantId};
 use diesel_models::add_ons::{AddOnRow, AddOnRowNew, AddOnRowPatch};
 use error_stack::Report;
-use uuid::Uuid;
 
 #[async_trait::async_trait]
 pub trait AddOnInterface {
@@ -15,10 +14,10 @@ pub trait AddOnInterface {
         pagination: PaginationRequest,
         search: Option<String>,
     ) -> StoreResult<PaginatedVec<AddOn>>;
-    async fn get_add_on_by_id(&self, tenant_id: TenantId, id: Uuid) -> StoreResult<AddOn>;
+    async fn get_add_on_by_id(&self, tenant_id: TenantId, id: AddOnId) -> StoreResult<AddOn>;
     async fn create_add_on(&self, add_on: AddOnNew) -> StoreResult<AddOn>;
     async fn update_add_on(&self, add_on: AddOnPatch) -> StoreResult<AddOn>;
-    async fn delete_add_on(&self, id: Uuid, tenant_id: TenantId) -> StoreResult<()>;
+    async fn delete_add_on(&self, id: AddOnId, tenant_id: TenantId) -> StoreResult<()>;
 }
 
 #[async_trait::async_trait]
@@ -46,7 +45,7 @@ impl AddOnInterface for Store {
         })
     }
 
-    async fn get_add_on_by_id(&self, tenant_id: TenantId, id: Uuid) -> StoreResult<AddOn> {
+    async fn get_add_on_by_id(&self, tenant_id: TenantId, id: AddOnId) -> StoreResult<AddOn> {
         let mut conn = self.get_conn().await?;
 
         AddOnRow::get_by_id(&mut conn, tenant_id, id)
@@ -79,7 +78,7 @@ impl AddOnInterface for Store {
             .and_then(TryInto::try_into)
     }
 
-    async fn delete_add_on(&self, id: Uuid, tenant_id: TenantId) -> StoreResult<()> {
+    async fn delete_add_on(&self, id: AddOnId, tenant_id: TenantId) -> StoreResult<()> {
         let mut conn = self.get_conn().await?;
 
         AddOnRow::delete(&mut conn, id, tenant_id)

--- a/modules/meteroid/crates/meteroid-store/src/repositories/invoices.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/invoices.rs
@@ -252,7 +252,7 @@ impl InvoiceInterface for Store {
 
                 let invoicing_entity = InvoicingEntityRow::select_for_update_by_id_and_tenant(
                     conn,
-                    &refreshed.customer.invoicing_entity_id,
+                    refreshed.customer.invoicing_entity_id,
                     tenant_id,
                 )
                 .await
@@ -279,7 +279,7 @@ impl InvoiceInterface for Store {
 
                 InvoicingEntityRow::update_invoicing_entity_number(
                     conn,
-                    &refreshed.customer.invoicing_entity_id,
+                    refreshed.customer.invoicing_entity_id,
                     tenant_id,
                     invoicing_entity.next_invoice_number,
                 )

--- a/modules/meteroid/crates/meteroid-store/src/repositories/price_components.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/price_components.rs
@@ -4,8 +4,7 @@ use error_stack::Report;
 
 use crate::domain::price_components::{PriceComponent, PriceComponentNew};
 use crate::errors::StoreError;
-use crate::utils::local_id::{IdType, LocalId};
-use common_domain::ids::TenantId;
+use common_domain::ids::{PriceComponentId, TenantId};
 use diesel_models::price_components::PriceComponentRow;
 use uuid::Uuid;
 
@@ -20,7 +19,7 @@ pub trait PriceComponentInterface {
     async fn get_price_component_by_id(
         &self,
         tenant_id: TenantId,
-        id: Uuid,
+        id: PriceComponentId,
     ) -> StoreResult<PriceComponent>;
 
     async fn create_price_component(
@@ -42,7 +41,7 @@ pub trait PriceComponentInterface {
 
     async fn delete_price_component(
         &self,
-        component_id: Uuid,
+        component_id: PriceComponentId,
         tenant_id: TenantId,
     ) -> StoreResult<()>;
 }
@@ -70,7 +69,7 @@ impl PriceComponentInterface for Store {
     async fn get_price_component_by_id(
         &self,
         tenant_id: TenantId,
-        price_component_id: Uuid,
+        price_component_id: PriceComponentId,
     ) -> StoreResult<PriceComponent> {
         let mut conn = self.get_conn().await?;
 
@@ -124,7 +123,6 @@ impl PriceComponentInterface for Store {
         let mut conn = self.get_conn().await?;
         let price_component: PriceComponentRow = PriceComponentRow {
             id: price_component.id,
-            local_id: LocalId::generate_for(IdType::PriceComponent),
             plan_version_id,
             name: price_component.name,
             product_id: price_component.product_id,
@@ -147,7 +145,7 @@ impl PriceComponentInterface for Store {
 
     async fn delete_price_component(
         &self,
-        component_id: Uuid,
+        component_id: PriceComponentId,
         tenant_id: TenantId,
     ) -> StoreResult<()> {
         let mut conn = self.get_conn().await?;

--- a/modules/meteroid/crates/meteroid-store/src/repositories/products.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/products.rs
@@ -1,29 +1,31 @@
 use crate::domain::{OrderByRequest, PaginatedVec, PaginationRequest, Product, ProductNew};
 use crate::errors::StoreError;
 use crate::store::Store;
-use crate::utils::local_id::{IdType, LocalId};
 use crate::StoreResult;
-use common_domain::ids::TenantId;
+use common_domain::ids::{BaseId, ProductFamilyId, ProductId, TenantId};
 use diesel_models::product_families::ProductFamilyRow;
 use diesel_models::products::{ProductRow, ProductRowNew};
 use error_stack::Report;
-use uuid::Uuid;
 
 #[async_trait::async_trait]
 pub trait ProductInterface {
     async fn create_product(&self, product: ProductNew) -> StoreResult<Product>;
-    async fn find_product_by_id(&self, id: Uuid, auth_tenant_id: TenantId) -> StoreResult<Product>;
+    async fn find_product_by_id(
+        &self,
+        id: ProductId,
+        auth_tenant_id: TenantId,
+    ) -> StoreResult<Product>;
     async fn list_products(
         &self,
         auth_tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<Product>>;
     async fn search_products(
         &self,
         auth_tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         query: &str,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
@@ -35,17 +37,12 @@ impl ProductInterface for Store {
     async fn create_product(&self, product: ProductNew) -> StoreResult<Product> {
         let mut conn = self.get_conn().await?;
 
-        let family = ProductFamilyRow::find_by_local_id_and_tenant_id(
-            &mut conn,
-            product.family_local_id.as_str(),
-            product.tenant_id,
-        )
-        .await
-        .map_err(Into::<Report<StoreError>>::into)?;
+        let family = ProductFamilyRow::find_by_id(&mut conn, product.family_id, product.tenant_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
 
         let insertable = ProductRowNew {
-            id: Uuid::now_v7(),
-            local_id: LocalId::generate_for(IdType::Product),
+            id: ProductId::new(),
             name: product.name,
             description: product.description,
             created_by: product.created_by,
@@ -60,7 +57,11 @@ impl ProductInterface for Store {
             .map(Into::into)
     }
 
-    async fn find_product_by_id(&self, id: Uuid, auth_tenant_id: TenantId) -> StoreResult<Product> {
+    async fn find_product_by_id(
+        &self,
+        id: ProductId,
+        auth_tenant_id: TenantId,
+    ) -> StoreResult<Product> {
         let mut conn = self.get_conn().await?;
 
         ProductRow::find_by_id_and_tenant_id(&mut conn, id, auth_tenant_id)
@@ -72,7 +73,7 @@ impl ProductInterface for Store {
     async fn list_products(
         &self,
         auth_tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
     ) -> StoreResult<PaginatedVec<Product>> {
@@ -81,7 +82,7 @@ impl ProductInterface for Store {
         let rows = ProductRow::list(
             &mut conn,
             auth_tenant_id,
-            family_local_id,
+            family_id,
             pagination.into(),
             order_by.into(),
         )
@@ -100,7 +101,7 @@ impl ProductInterface for Store {
     async fn search_products(
         &self,
         auth_tenant_id: TenantId,
-        family_local_id: Option<String>,
+        family_id: Option<ProductFamilyId>,
         query: &str,
         pagination: PaginationRequest,
         order_by: OrderByRequest,
@@ -110,7 +111,7 @@ impl ProductInterface for Store {
         let rows = ProductRow::search(
             &mut conn,
             auth_tenant_id,
-            family_local_id,
+            family_id,
             query,
             pagination.into(),
             order_by.into(),

--- a/modules/meteroid/crates/meteroid-store/src/utils/local_id.rs
+++ b/modules/meteroid/crates/meteroid-store/src/utils/local_id.rs
@@ -2,42 +2,12 @@ use nanoid::nanoid;
 
 #[derive(Debug)]
 pub enum IdType {
-    AddOn,
-    BankAccount,
-    BillableMetric,
-    Coupon,
-    Customer,
-    Invoice,
-    InvoicingEntity,
     Other,
-    Plan,
-    PriceComponent,
-    Product,
-    ProductFamily,
-    Subscription,
-    Tenant,
-    Event,
 }
 
 impl IdType {
     fn prefix(&self) -> &'static str {
-        match self {
-            IdType::AddOn => "add_",
-            IdType::BankAccount => "ba_",
-            IdType::BillableMetric => "bm_",
-            IdType::Coupon => "cou_",
-            IdType::Customer => "cus_",
-            IdType::Event => "evt_",
-            IdType::Invoice => "inv_",
-            IdType::InvoicingEntity => "ive_",
-            IdType::Plan => "plan_",
-            IdType::PriceComponent => "price_",
-            IdType::Product => "prd_",
-            IdType::ProductFamily => "pf_",
-            IdType::Subscription => "sub_",
-            IdType::Tenant => "",
-            _ => "",
-        }
+        ""
     }
 }
 

--- a/modules/meteroid/migrations/diesel/2025-02-26-201256_delete_local_id/down.sql
+++ b/modules/meteroid/migrations/diesel/2025-02-26-201256_delete_local_id/down.sql
@@ -1,0 +1,43 @@
+ALTER TABLE "invoicing_entity"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "add_on"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "bank_account"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "billable_metric"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "coupon"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "credit_note"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "outbox_event"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "product_family"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "product"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");
+
+ALTER TABLE "price_component"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("plan_version_id", "local_id");
+
+ALTER TABLE "plan"
+  ADD COLUMN "local_id" TEXT NOT NULL DEFAULT gen_random_uuid()::TEXT,
+  ADD UNIQUE ("tenant_id", "local_id");

--- a/modules/meteroid/migrations/diesel/2025-02-26-201256_delete_local_id/up.sql
+++ b/modules/meteroid/migrations/diesel/2025-02-26-201256_delete_local_id/up.sql
@@ -1,0 +1,11 @@
+alter table invoicing_entity drop column local_id;
+alter table add_on drop column local_id;
+alter table bank_account drop column local_id;
+alter table billable_metric drop column local_id;
+alter table coupon drop column local_id;
+alter table credit_note drop column local_id;
+alter table outbox_event drop column local_id;
+alter table product_family drop column local_id;
+alter table product drop column local_id;
+alter table price_component drop column local_id;
+alter table plan drop column local_id;

--- a/modules/meteroid/src/api/addons/mapping.rs
+++ b/modules/meteroid/src/api/addons/mapping.rs
@@ -7,7 +7,7 @@ pub mod addons {
         fn from(value: domain::add_ons::AddOn) -> Self {
             Self(server::AddOn {
                 id: value.id.to_string(),
-                local_id: value.local_id,
+                local_id: value.id.to_string(), //todo remove me
                 name: value.name,
                 fee: Some(
                     crate::api::pricecomponents::mapping::components::map_fee_domain_to_api(

--- a/modules/meteroid/src/api/addons/service.rs
+++ b/modules/meteroid/src/api/addons/service.rs
@@ -2,7 +2,7 @@ use crate::api::addons::error::AddOnApiError;
 use crate::api::addons::mapping::addons::AddOnWrapper;
 use crate::api::addons::AddOnsServiceComponents;
 use crate::api::utils::PaginationExt;
-use crate::{api::utils::parse_uuid, parse_uuid};
+use common_domain::ids::AddOnId;
 use common_grpc::middleware::server::auth::RequestExt;
 use meteroid_grpc::meteroid::api::addons::v1::add_ons_service_server::AddOnsService;
 use meteroid_grpc::meteroid::api::addons::v1::{
@@ -85,7 +85,7 @@ impl AddOnsService for AddOnsServiceComponents {
 
         let req = request.into_inner();
 
-        let add_on_id = parse_uuid!(&req.add_on_id)?;
+        let add_on_id = AddOnId::from_proto(&req.add_on_id)?;
 
         self.store
             .delete_add_on(add_on_id, tenant_id)
@@ -111,7 +111,7 @@ impl AddOnsService for AddOnsServiceComponents {
         let fee = crate::api::pricecomponents::mapping::components::map_fee_to_domain(add_on.fee)?;
 
         let patch = AddOnPatch {
-            id: parse_uuid!(&add_on.id)?,
+            id: AddOnId::from_proto(&add_on.id)?,
             tenant_id,
             name: Some(add_on.name),
             fee: Some(fee),

--- a/modules/meteroid/src/api/bankaccounts/mapping.rs
+++ b/modules/meteroid/src/api/bankaccounts/mapping.rs
@@ -1,12 +1,10 @@
 pub mod bank_accounts {
     use crate::api::bankaccounts::error::BankAccountsApiError;
-    use crate::api::shared::conversions::ProtoConv;
     use meteroid_grpc::meteroid::api::bankaccounts::v1 as server;
 
     use meteroid_store::domain::bank_accounts as domain;
-    use meteroid_store::utils::local_id::{IdType, LocalId};
 
-    use common_domain::ids::TenantId;
+    use common_domain::ids::{BankAccountId, BaseId, TenantId};
     use uuid::Uuid;
 
     mod format {
@@ -156,8 +154,7 @@ pub mod bank_accounts {
         );
 
         Ok(domain::BankAccountNew {
-            id: Default::default(),
-            local_id: LocalId::generate_for(IdType::BankAccount),
+            id: BankAccountId::new(),
             created_by: actor,
             tenant_id,
             country: proto.country,
@@ -170,8 +167,8 @@ pub mod bank_accounts {
 
     pub fn domain_to_proto(domain: domain::BankAccount) -> server::BankAccount {
         server::BankAccount {
-            id: domain.id.to_string(),
-            local_id: domain.local_id.to_string(),
+            id: domain.id.as_proto(),
+            local_id: domain.id.as_proto(), //todo remove me
             data: Some(server::BankAccountData {
                 country: domain.country,
                 bank_name: domain.bank_name,
@@ -198,7 +195,7 @@ pub mod bank_accounts {
         );
 
         Ok(domain::BankAccountPatch {
-            id: Uuid::from_proto(proto.id).unwrap(),
+            id: BankAccountId::from_proto(proto.id).unwrap(),
             tenant_id,
             country: Some(data.country),
             bank_name: Some(data.bank_name),

--- a/modules/meteroid/src/api/bankaccounts/service.rs
+++ b/modules/meteroid/src/api/bankaccounts/service.rs
@@ -1,4 +1,4 @@
-use common_domain::ids::BaseId;
+use common_domain::ids::{BankAccountId, BaseId};
 use common_grpc::middleware::server::auth::RequestExt;
 use meteroid_grpc::meteroid::api::bankaccounts::v1::{
     bank_accounts_service_server::BankAccountsService, CreateBankAccountRequest,
@@ -7,12 +7,10 @@ use meteroid_grpc::meteroid::api::bankaccounts::v1::{
     UpdateBankAccountResponse,
 };
 use tonic::{Request, Response, Status};
-use uuid::Uuid;
 
 use meteroid_store::repositories::bank_accounts::BankAccountsInterface;
 
 use crate::api::bankaccounts::error::BankAccountsApiError;
-use crate::api::shared::conversions::ProtoConv;
 
 use super::{mapping, BankAccountsServiceComponents};
 
@@ -96,10 +94,10 @@ impl BankAccountsService for BankAccountsServiceComponents {
         request: Request<DeleteBankAccountRequest>,
     ) -> Result<Response<DeleteBankAccountResponse>, Status> {
         let tenant = request.tenant()?;
-        let id = Uuid::from_proto(request.into_inner().id)?;
+        let id = BankAccountId::from_proto(request.into_inner().id)?;
 
         self.store
-            .delete_bank_account(&id, tenant)
+            .delete_bank_account(id, tenant)
             .await
             .map_err(Into::<BankAccountsApiError>::into)?;
 

--- a/modules/meteroid/src/api/billablemetrics/mapping.rs
+++ b/modules/meteroid/src/api/billablemetrics/mapping.rs
@@ -95,7 +95,6 @@ pub mod metric {
     use meteroid_grpc::meteroid::api::billablemetrics::v1 as server;
     use std::collections::HashMap;
 
-    use crate::api::shared::conversions::AsProtoOpt;
     use crate::api::shared::mapping::datetime::chrono_to_timestamp;
     use metering_grpc::meteroid::metering::v1 as metering;
     use meteroid_grpc::meteroid::api::billablemetrics::v1::segmentation_matrix::Matrix;
@@ -110,8 +109,8 @@ pub mod metric {
 
         fn try_from(value: domain::BillableMetric) -> Result<Self, Self::Error> {
             Ok(ServerBillableMetricWrapper(server::BillableMetric {
-                id: value.id.to_string(),
-                local_id: value.local_id,
+                id: value.id.as_proto(),
+                local_id: value.id.as_proto(), //todo remove me
                 name: value.name,
                 code: value.code,
                 description: value.description,
@@ -134,7 +133,7 @@ pub mod metric {
                 archived_at: value.archived_at.map(chrono_to_timestamp),
                 created_at: Some(chrono_to_timestamp(value.created_at)),
                 usage_group_key: value.usage_group_key,
-                product_id: value.product_id.as_proto(),
+                product_id: value.product_id.map(|x| x.as_proto()),
             }))
         }
     }
@@ -147,7 +146,7 @@ pub mod metric {
         fn try_from(value: domain::BillableMetricMeta) -> Result<Self, Self::Error> {
             Ok(ServerBillableMetricMetaWrapper(
                 server::BillableMetricMeta {
-                    id: value.id.to_string(),
+                    id: value.id.as_proto(),
                     name: value.name,
                     code: value.code,
                     aggregation_type: super::aggregation_type::domain_to_server(
@@ -269,7 +268,7 @@ pub mod metric {
             .unwrap_or_default();
 
         metering::Meter {
-            id: metric.local_id, // we could allow optional external_id if the metric is defined externally
+            id: metric.id.as_proto(), // we could allow optional external_id if the metric is defined externally
             event_name: metric.code.to_string(),
             aggregation_key: metric.aggregation_key,
             aggregation: super::aggregation_type::domain_to_metering(metric.aggregation_type)

--- a/modules/meteroid/src/api/coupons/mapping.rs
+++ b/modules/meteroid/src/api/coupons/mapping.rs
@@ -14,7 +14,7 @@ pub mod applied {
                 customer_id: value.customer_id.as_proto(),
                 subscription_id: value.subscription_id.as_proto(),
                 plan_name: value.plan_name,
-                plan_local_id: value.plan_local_id,
+                plan_local_id: value.id.as_proto(), // todo remove me
                 plan_version: value.plan_version,
                 is_active: value.is_active,
                 applied_amount: value.applied_amount.as_proto(),
@@ -34,8 +34,8 @@ pub mod coupons {
     impl From<domain::coupons::Coupon> for CouponWrapper {
         fn from(value: domain::coupons::Coupon) -> Self {
             Self(server::Coupon {
-                id: value.id.to_string(),
-                local_id: value.local_id,
+                id: value.id.as_proto(),
+                local_id: value.id.as_proto(), //todo remove me
                 description: value.description,
                 code: value.code,
                 discount: Some(discount::to_server(&value.discount)),

--- a/modules/meteroid/src/api/invoices/mapping.rs
+++ b/modules/meteroid/src/api/invoices/mapping.rs
@@ -82,15 +82,15 @@ pub mod invoices {
                     id: line.local_id,
                     name: line.name,
                     subtotal: line.subtotal,
-                    metric_id: line.metric_id.as_proto(),
-                    price_component_id: line.price_component_id.as_proto(),
+                    metric_id: line.metric_id.map(|x| x.as_proto()),
+                    price_component_id: line.price_component_id.map(|x| x.as_proto()),
                     end_date: line.end_date.as_proto(),
                     start_date: line.start_date.as_proto(),
                     quantity: line.quantity.as_proto(),
                     total: line.total,
                     unit_price: line.unit_price.as_proto(),
                     is_prorated: line.is_prorated,
-                    product_id: line.product_id.as_proto(),
+                    product_id: line.product_id.map(|x| x.as_proto()),
                     description: line.description,
                     sub_line_items: line.sub_lines.into_iter().map(
                         |sub_line| {

--- a/modules/meteroid/src/api/invoicingentities/mapping.rs
+++ b/modules/meteroid/src/api/invoicingentities/mapping.rs
@@ -1,8 +1,7 @@
 pub mod invoicing_entities {
-    use crate::api::shared::conversions::ProtoConv;
+    use common_domain::ids::InvoicingEntityId;
     use meteroid_grpc::meteroid::api::invoicingentities::v1 as server;
     use meteroid_store::domain::invoicing_entities as domain;
-    use uuid::Uuid;
 
     pub fn proto_to_domain(proto: server::InvoicingEntityData) -> domain::InvoicingEntityNew {
         domain::InvoicingEntityNew {
@@ -28,7 +27,7 @@ pub mod invoicing_entities {
 
     pub fn proto_to_patch_domain(
         proto: server::InvoicingEntityData,
-        id: Uuid,
+        id: InvoicingEntityId,
     ) -> domain::InvoicingEntityPatch {
         domain::InvoicingEntityPatch {
             id,
@@ -55,7 +54,7 @@ pub mod invoicing_entities {
     pub fn domain_to_proto(domain: domain::InvoicingEntity) -> server::InvoicingEntity {
         server::InvoicingEntity {
             id: domain.id.as_proto(),
-            local_id: domain.local_id,
+            local_id: domain.id.as_proto(), // todo remove me
             is_default: domain.is_default,
             legal_name: domain.legal_name,
             invoice_number_pattern: domain.invoice_number_pattern,

--- a/modules/meteroid/src/api/plans/mapping.rs
+++ b/modules/meteroid/src/api/plans/mapping.rs
@@ -42,8 +42,8 @@ pub mod plans {
             fn trial_config(version: &domain::PlanVersion) -> Option<TrialConfig> {
                 match version.trial_duration_days {
                     Some(days) if days > 0 => Some(TrialConfig {
-                        trialing_plan_id: version.trialing_plan_id.as_proto(),
-                        downgrade_plan_id: version.downgrade_plan_id.as_proto(),
+                        trialing_plan_id: version.trialing_plan_id.map(|x| x.as_proto()),
+                        downgrade_plan_id: version.downgrade_plan_id.map(|x| x.as_proto()),
                         action_after_trial: version
                             .action_after_trial
                             .as_ref()
@@ -99,8 +99,8 @@ pub mod plans {
         fn from(value: domain::FullPlan) -> Self {
             Self(PlanWithVersion {
                 plan: Some(Plan {
-                    id: value.plan.id.to_string(),
-                    local_id: value.plan.local_id,
+                    id: value.plan.id.as_proto(),
+                    local_id: value.plan.id.as_proto(),
                     name: value.plan.name,
                     description: value.plan.description,
                     plan_type: PlanTypeWrapper::from(value.plan.plan_type).0 as i32,
@@ -117,8 +117,8 @@ pub mod plans {
         fn from(value: domain::PlanWithVersion) -> Self {
             Self(PlanWithVersion {
                 plan: Some(Plan {
-                    id: value.plan.id.to_string(),
-                    local_id: value.plan.local_id,
+                    id: value.plan.id.as_proto(),
+                    local_id: value.plan.id.as_proto(), //todo remove me
                     name: value.plan.name,
                     description: value.plan.description,
                     plan_type: PlanTypeWrapper::from(value.plan.plan_type).0 as i32,
@@ -196,14 +196,14 @@ pub mod plans {
     impl From<domain::PlanOverview> for PlanOverviewWrapper {
         fn from(value: domain::PlanOverview) -> Self {
             Self(PlanOverview {
-                id: value.id.to_string(),
+                id: value.id.as_proto(),
                 name: value.name,
-                local_id: value.local_id,
+                local_id: value.id.as_proto(), //todo remove me
                 description: value.description,
                 plan_type: PlanTypeWrapper::from(value.plan_type).0 as i32,
                 plan_status: PlanStatusWrapper::from(value.status).0 as i32,
                 product_family_name: value.product_family_name,
-                product_family_local_id: value.product_family_local_id,
+                product_family_local_id: value.product_family_id.as_proto(), // todo rename product_family_local_id
                 created_at: value.created_at.as_proto(),
                 has_draft_version: value.has_draft_version,
                 active_version: value.active_version.map(|v| ActiveVersionInfo {

--- a/modules/meteroid/src/api/pricecomponents/service.rs
+++ b/modules/meteroid/src/api/pricecomponents/service.rs
@@ -1,4 +1,4 @@
-use common_domain::ids::BaseId;
+use common_domain::ids::{BaseId, PriceComponentId};
 use common_grpc::middleware::server::auth::RequestExt;
 use meteroid_grpc::meteroid::api::components::v1::{
     price_components_service_server::PriceComponentsService, CreatePriceComponentRequest,
@@ -78,7 +78,7 @@ impl PriceComponentsService for PriceComponentServiceComponents {
             .eventbus
             .publish(Event::price_component_created(
                 actor,
-                component.id,
+                component.id.as_uuid(),
                 tenant_id.as_uuid(),
             ))
             .await;
@@ -118,7 +118,7 @@ impl PriceComponentsService for PriceComponentServiceComponents {
             .eventbus
             .publish(Event::price_component_edited(
                 actor,
-                component.id,
+                component.id.as_uuid(),
                 tenant_id.as_uuid(),
             ))
             .await;
@@ -137,7 +137,7 @@ impl PriceComponentsService for PriceComponentServiceComponents {
         let tenant_id = request.tenant()?;
         let req = request.into_inner();
 
-        let price_component_id = parse_uuid(&req.price_component_id, "price_component_id")?;
+        let price_component_id = PriceComponentId::from_proto(&req.price_component_id)?;
 
         self.store
             .delete_price_component(price_component_id, tenant_id)
@@ -154,7 +154,7 @@ impl PriceComponentsService for PriceComponentServiceComponents {
             .eventbus
             .publish(Event::price_component_removed(
                 actor,
-                price_component_id,
+                price_component_id.as_uuid(),
                 tenant_id.as_uuid(),
             ))
             .await;

--- a/modules/meteroid/src/api/productfamilies/mapping.rs
+++ b/modules/meteroid/src/api/productfamilies/mapping.rs
@@ -7,9 +7,9 @@ pub mod product_family {
     impl From<domain::ProductFamily> for ProductFamilyWrapper {
         fn from(domain_family: domain::ProductFamily) -> Self {
             ProductFamilyWrapper(ProductFamily {
-                id: domain_family.id.to_string(),
+                id: domain_family.id.as_proto(),
                 name: domain_family.name,
-                local_id: domain_family.local_id,
+                local_id: domain_family.id.as_proto(), //todo remove me
             })
         }
     }

--- a/modules/meteroid/src/api/productitems/mapping.rs
+++ b/modules/meteroid/src/api/productitems/mapping.rs
@@ -1,15 +1,14 @@
 pub mod products {
+    use crate::api::shared::mapping::datetime::chrono_to_timestamp;
     use meteroid_grpc::meteroid::api::products::v1::{Product, ProductMeta};
     use meteroid_store::domain;
-
-    use crate::api::shared::mapping::datetime::chrono_to_timestamp;
     pub struct ProductWrapper(pub Product);
 
     impl From<domain::Product> for ProductWrapper {
         fn from(product: domain::Product) -> Self {
             ProductWrapper(Product {
-                id: product.id.to_string(),
-                local_id: product.local_id,
+                id: product.id.as_proto(),
+                local_id: product.id.as_proto(), //todo remove me
                 name: product.name,
                 description: product.description,
                 created_at: Some(chrono_to_timestamp(product.created_at)),
@@ -21,8 +20,8 @@ pub mod products {
     impl From<domain::Product> for ProductMetaWrapper {
         fn from(product: domain::Product) -> Self {
             ProductMetaWrapper(ProductMeta {
-                id: product.id.to_string(),
-                local_id: product.local_id,
+                id: product.id.as_proto(),
+                local_id: product.id.as_proto(), //todo remove me
                 name: product.name,
             })
         }

--- a/modules/meteroid/src/api_rest/customers/mapping.rs
+++ b/modules/meteroid/src/api_rest/customers/mapping.rs
@@ -6,10 +6,10 @@ use crate::api_rest::customers::model::{
 use crate::errors::RestApiError;
 use common_domain::ids::{AliasOr, CustomerId};
 use meteroid_store::domain;
-use meteroid_store::domain::{CustomerNew, Identity};
+use meteroid_store::domain::CustomerNew;
 use uuid::Uuid;
 
-pub fn domain_to_rest(d: domain::CustomerForDisplay) -> Result<Customer, RestApiError> {
+pub fn domain_to_rest(d: domain::Customer) -> Result<Customer, RestApiError> {
     Ok(Customer {
         id: d.id,
         name: d.name,
@@ -25,7 +25,7 @@ pub fn domain_to_rest(d: domain::CustomerForDisplay) -> Result<Customer, RestApi
             .map(addresses::mapping::shipping_address::domain_to_rest),
         currency: currencies::mapping::from_str(d.currency.as_str())?,
         billing_config: d.billing_config.into(),
-        invoicing_entity_id: d.invoicing_entity_local_id,
+        invoicing_entity_id: d.invoicing_entity_id,
     })
 }
 
@@ -52,7 +52,7 @@ pub fn create_req_to_domain(created_by: Uuid, req: CustomerCreateRequest) -> Cus
     CustomerNew {
         name: req.name,
         created_by,
-        invoicing_entity_id: req.invoicing_entity_id.map(Identity::LOCAL),
+        invoicing_entity_id: req.invoicing_entity_id,
         billing_config: billing_config_to_domain(req.billing_config),
         alias: req.alias,
         email: req.email,
@@ -77,7 +77,7 @@ pub fn update_req_to_domain(
     domain::CustomerUpdate {
         id_or_alias,
         name: req.name,
-        invoicing_entity_id: Identity::LOCAL(req.invoicing_entity_id),
+        invoicing_entity_id: req.invoicing_entity_id,
         billing_config: billing_config_to_domain(req.billing_config),
         alias: req.alias,
         email: req.email,

--- a/modules/meteroid/src/api_rest/customers/model.rs
+++ b/modules/meteroid/src/api_rest/customers/model.rs
@@ -1,8 +1,8 @@
 use crate::api_rest::addresses::model::{Address, ShippingAddress};
 use crate::api_rest::currencies::model::Currency;
 use crate::api_rest::model::PaginatedRequest;
-use common_domain::ids::string_serde;
 use common_domain::ids::CustomerId;
+use common_domain::ids::{string_serde, string_serde_opt, InvoicingEntityId};
 use meteroid_store::domain;
 use utoipa::ToSchema;
 use validator::Validate;
@@ -34,7 +34,8 @@ pub struct Customer {
     pub billing_address: Option<Address>,
     pub shipping_address: Option<ShippingAddress>,
     pub currency: Currency,
-    pub invoicing_entity_id: String,
+    #[serde(with = "string_serde")]
+    pub invoicing_entity_id: InvoicingEntityId,
     pub billing_config: BillingConfig, // todo revisit how we present billing config in the API
 }
 
@@ -88,7 +89,8 @@ pub struct CustomerCreateRequest {
     pub currency: Currency,
     pub billing_address: Option<Address>,
     pub shipping_address: Option<ShippingAddress>,
-    pub invoicing_entity_id: Option<String>,
+    #[serde(with = "string_serde_opt")]
+    pub invoicing_entity_id: Option<InvoicingEntityId>,
 }
 
 #[derive(ToSchema, serde::Serialize, serde::Deserialize, Validate)]
@@ -102,5 +104,6 @@ pub struct CustomerUpdateRequest {
     pub currency: Currency,
     pub billing_address: Option<Address>,
     pub shipping_address: Option<ShippingAddress>,
-    pub invoicing_entity_id: String,
+    #[serde(with = "string_serde")]
+    pub invoicing_entity_id: InvoicingEntityId,
 }

--- a/modules/meteroid/src/api_rest/customers/router.rs
+++ b/modules/meteroid/src/api_rest/customers/router.rs
@@ -44,7 +44,7 @@ pub(crate) async fn list_customers(
 ) -> Result<impl IntoResponse, RestApiError> {
     let res = app_state
         .store
-        .list_customers_for_display(
+        .list_customers(
             authorized_state.tenant_id,
             domain::PaginationRequest {
                 page: request.pagination.offset.unwrap_or(0),

--- a/modules/meteroid/src/api_rest/plans/mapping.rs
+++ b/modules/meteroid/src/api_rest/plans/mapping.rs
@@ -3,14 +3,14 @@ use meteroid_store::domain;
 
 pub fn domain_to_rest(d: domain::PlanOverview) -> Plan {
     Plan {
-        id: d.local_id,
+        id: d.id,
         name: d.name,
         description: d.description,
         created_at: d.created_at,
         plan_type: d.plan_type.into(),
         status: d.status.into(),
         product_family_name: d.product_family_name,
-        product_family_id: d.product_family_local_id,
+        product_family_id: d.product_family_id,
         has_draft_version: d.has_draft_version,
         subscription_count: d.subscription_count,
     }

--- a/modules/meteroid/src/api_rest/plans/model.rs
+++ b/modules/meteroid/src/api_rest/plans/model.rs
@@ -1,5 +1,6 @@
 use crate::api_rest::model::PaginatedRequest;
 use chrono::NaiveDateTime;
+use common_domain::ids::{string_serde, string_serde_opt, PlanId, ProductFamilyId};
 use meteroid_store::domain;
 use serde_enum_str::{Deserialize_enum_str, Serialize_enum_str};
 use utoipa::ToSchema;
@@ -10,7 +11,8 @@ pub struct PlanListRequest {
     #[serde(flatten)]
     #[validate(nested)]
     pub pagination: PaginatedRequest,
-    pub product_family_id: Option<String>,
+    #[serde(with = "string_serde_opt")]
+    pub product_family_id: Option<ProductFamilyId>,
     #[serde(flatten)]
     pub plan_filters: PlanFilters,
 }
@@ -22,14 +24,16 @@ pub struct PlanFilters {
 
 #[derive(Clone, ToSchema, serde::Serialize, serde::Deserialize)]
 pub struct Plan {
-    pub id: String,
+    #[serde(with = "string_serde")]
+    pub id: PlanId,
     pub name: String,
     pub description: Option<String>,
     pub created_at: NaiveDateTime,
     pub plan_type: PlanTypeEnum,
     pub status: PlanStatusEnum,
     pub product_family_name: String,
-    pub product_family_id: String,
+    #[serde(with = "string_serde")]
+    pub product_family_id: ProductFamilyId,
     // #[from(~.map(| v | v.into()))]
     // pub active_version: Option<PlanVersionInfo>,
     // pub draft_version: Option<Uuid>,

--- a/modules/meteroid/src/api_rest/plans/router.rs
+++ b/modules/meteroid/src/api_rest/plans/router.rs
@@ -9,7 +9,7 @@ use crate::api_rest::plans::model::{Plan, PlanFilters, PlanListRequest};
 use crate::errors::RestApiError;
 use axum::Extension;
 use axum_valid::Valid;
-use common_domain::ids::TenantId;
+use common_domain::ids::{ProductFamilyId, TenantId};
 use common_grpc::middleware::server::auth::AuthorizedAsTenant;
 use meteroid_store::domain::OrderByRequest;
 use meteroid_store::repositories::PlansInterface;
@@ -59,13 +59,13 @@ async fn list_plans_handler(
     store: Store,
     pagination: PaginatedRequest,
     tenant_id: TenantId,
-    product_family_local_id: Option<String>,
+    product_family_id: Option<ProductFamilyId>,
     plan_filters: PlanFilters,
 ) -> Result<PaginatedResponse<Plan>, RestApiError> {
     let res = store
         .list_plans(
             tenant_id,
-            product_family_local_id,
+            product_family_id,
             domain::PlanFilters {
                 search: plan_filters.search,
                 filter_status: Vec::new(),

--- a/modules/meteroid/src/api_rest/productfamilies/mapping.rs
+++ b/modules/meteroid/src/api_rest/productfamilies/mapping.rs
@@ -5,7 +5,7 @@ use meteroid_store::domain::ProductFamilyNew;
 
 pub(crate) fn domain_to_rest(d: domain::ProductFamily) -> ProductFamily {
     ProductFamily {
-        id: d.local_id,
+        id: d.id,
         name: d.name,
     }
 }

--- a/modules/meteroid/src/api_rest/productfamilies/model.rs
+++ b/modules/meteroid/src/api_rest/productfamilies/model.rs
@@ -1,4 +1,5 @@
 use crate::api_rest::model::PaginatedRequest;
+use common_domain::ids::{string_serde, ProductFamilyId};
 use utoipa::ToSchema;
 use validator::Validate;
 
@@ -19,7 +20,8 @@ pub struct ProductFamilyListRequest {
 
 #[derive(Clone, ToSchema, serde::Serialize, serde::Deserialize)]
 pub struct ProductFamily {
-    pub id: String,
+    #[serde(with = "string_serde")]
+    pub id: ProductFamilyId,
     pub name: String,
 }
 

--- a/modules/meteroid/src/api_rest/subscriptions/model.rs
+++ b/modules/meteroid/src/api_rest/subscriptions/model.rs
@@ -1,7 +1,7 @@
 use crate::api_rest::model::PaginatedRequest;
-use common_domain::ids::string_serde_opt;
 use common_domain::ids::CustomerId;
 use common_domain::ids::{string_serde, SubscriptionId};
+use common_domain::ids::{string_serde_opt, PlanId};
 use utoipa::ToSchema;
 use validator::Validate;
 
@@ -12,7 +12,8 @@ pub struct SubscriptionRequest {
     pub pagination: PaginatedRequest,
     #[serde(with = "string_serde_opt")]
     pub customer_id: Option<CustomerId>,
-    pub plan_id: Option<String>,
+    #[serde(with = "string_serde_opt")]
+    pub plan_id: Option<PlanId>,
 }
 
 #[derive(Clone, ToSchema, serde::Serialize, serde::Deserialize)]

--- a/modules/meteroid/src/api_rest/subscriptions/router.rs
+++ b/modules/meteroid/src/api_rest/subscriptions/router.rs
@@ -11,9 +11,8 @@ use crate::api_rest::subscriptions::model::{
 use crate::errors::RestApiError;
 use axum::Extension;
 use axum_valid::Valid;
-use common_domain::ids::{CustomerId, SubscriptionId, TenantId};
+use common_domain::ids::{CustomerId, PlanId, SubscriptionId, TenantId};
 use common_grpc::middleware::server::auth::AuthorizedAsTenant;
-use meteroid_store::domain::Identity;
 use meteroid_store::repositories::SubscriptionInterface;
 use meteroid_store::{domain, Store};
 
@@ -60,13 +59,13 @@ async fn list_subscriptions_handler(
     pagination: PaginatedRequest,
     tenant_id: TenantId,
     customer_id: Option<CustomerId>,
-    plan_id: Option<String>,
+    plan_id: Option<PlanId>,
 ) -> Result<PaginatedResponse<Subscription>, RestApiError> {
     let res = store
         .list_subscriptions(
             tenant_id,
             customer_id,
-            plan_id.map(Identity::LOCAL),
+            plan_id,
             domain::PaginationRequest {
                 page: pagination.offset.unwrap_or(0),
                 per_page: pagination.limit,

--- a/modules/meteroid/src/clients/usage.rs
+++ b/modules/meteroid/src/clients/usage.rs
@@ -1,6 +1,6 @@
 use crate::api::billablemetrics::mapping;
 use chrono::{NaiveDate, Timelike};
-use common_domain::ids::CustomerId;
+use common_domain::ids::{CustomerId, TenantId};
 use common_grpc::middleware::client::LayeredClientService;
 use metering_grpc::meteroid::metering::v1::meter::AggregationType;
 use metering_grpc::meteroid::metering::v1::meters_service_client::MetersServiceClient;
@@ -15,7 +15,6 @@ use meteroid_store::domain;
 use meteroid_store::domain::{BillableMetric, Period};
 use rust_decimal::Decimal;
 use tonic::Request;
-use uuid::Uuid;
 
 #[derive(Clone, Debug)]
 pub struct MeteringUsageClient {
@@ -39,7 +38,7 @@ impl MeteringUsageClient {
 impl UsageClient for MeteringUsageClient {
     async fn register_meter(
         &self,
-        tenant_id: &Uuid,
+        tenant_id: TenantId,
         metric: &BillableMetric,
     ) -> Result<Vec<Metadata>, ComputeError> {
         let metering_meter = mapping::metric::domain_to_metering(metric.clone());
@@ -73,7 +72,7 @@ impl UsageClient for MeteringUsageClient {
 
     async fn fetch_usage(
         &self,
-        tenant_id: &Uuid,
+        tenant_id: TenantId,
         customer_id: CustomerId,
         customer_alias: &Option<String>,
         metric: &BillableMetric,

--- a/modules/meteroid/src/eventbus/analytics_handler.rs
+++ b/modules/meteroid/src/eventbus/analytics_handler.rs
@@ -117,7 +117,7 @@ impl AnalyticsHandler {
         let billable_metric = self
             .store
             .find_billable_metric_by_id(
-                event_data_details.entity_id,
+                event_data_details.entity_id.into(),
                 event_data_details.tenant_id.into(),
             )
             .await
@@ -391,7 +391,7 @@ impl AnalyticsHandler {
             .store
             .get_price_component_by_id(
                 event_data_details.tenant_id.into(),
-                event_data_details.entity_id,
+                event_data_details.entity_id.into(),
             )
             .await
             .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;
@@ -419,7 +419,7 @@ impl AnalyticsHandler {
             .store
             .get_price_component_by_id(
                 event_data_details.tenant_id.into(),
-                event_data_details.entity_id,
+                event_data_details.entity_id.into(),
             )
             .await
             .map_err(|e| EventBusError::EventHandlerFailed(e.to_string()))?;

--- a/modules/meteroid/src/seeder/runner.rs
+++ b/modules/meteroid/src/seeder/runner.rs
@@ -28,7 +28,7 @@ use chrono::Utc;
 
 use common_domain::ids::OrganizationId;
 use meteroid_store::domain::{
-    Address, BillingConfig, Identity, InlineCustomer, InlineInvoicingEntity, OrderByRequest,
+    Address, BillingConfig, InlineCustomer, InlineInvoicingEntity, OrderByRequest,
     PaginationRequest, TenantContext,
 };
 use meteroid_store::repositories::billable_metrics::BillableMetricInterface;
@@ -104,7 +104,7 @@ pub async fn run(
                 usage_group_key: None,
                 description: None,
                 created_by: user_id,
-                family_local_id: product_family.local_id.clone(),
+                product_family_id: product_family.id,
                 product_id: None, // TODO
             })
             .await
@@ -118,12 +118,11 @@ pub async fn run(
         let created = store
             .insert_plan(store_domain::FullPlanNew {
                 plan: store_domain::PlanNew {
-                    local_id: slugify(&plan.name),
                     name: plan.name,
                     plan_type: plan.plan_type,
                     status: PlanStatusEnum::Active,
                     tenant_id: tenant.id,
-                    product_family_local_id: product_family.local_id.clone(),
+                    product_family_id: product_family.id,
                     description: plan.description,
                     created_by: user_id,
                 },
@@ -177,7 +176,7 @@ pub async fn run(
 
             let alias = format!("{}-{}", slugify(&company_name), nanoid!(5));
             customers_to_create.push(store_domain::CustomerNew {
-                invoicing_entity_id: Some(Identity::UUID(invoicing_entity.id)),
+                invoicing_entity_id: Some(invoicing_entity.id),
                 billing_config: BillingConfig::Manual,
                 email: SafeEmail().fake(),
                 invoicing_email: None,

--- a/modules/meteroid/src/services/invoice_rendering.rs
+++ b/modules/meteroid/src/services/invoice_rendering.rs
@@ -2,11 +2,11 @@ use crate::errors::InvoicingRenderError;
 use crate::services::storage::{ObjectStoreService, Prefix};
 use base64::engine::general_purpose::STANDARD as Base64Engine;
 use base64::Engine;
-use common_domain::ids::{InvoiceId, TenantId};
+use common_domain::ids::{InvoiceId, InvoicingEntityId, TenantId};
 use error_stack::ResultExt;
 use image::ImageFormat::Png;
 use meteroid_invoicing::{html_render, pdf};
-use meteroid_store::domain::{Identity, Invoice, InvoicingEntity};
+use meteroid_store::domain::{Invoice, InvoicingEntity};
 use meteroid_store::repositories::historical_rates::HistoricalRatesInterface;
 use meteroid_store::repositories::invoicing_entities::InvoicingEntityInterface;
 use meteroid_store::repositories::InvoiceInterface;
@@ -37,10 +37,7 @@ impl HtmlRenderingService {
 
         let invoicing_entity = self
             .store
-            .get_invoicing_entity(
-                tenant_id,
-                Some(Identity::UUID(invoice.invoice.seller_details.id)),
-            )
+            .get_invoicing_entity(tenant_id, Some(invoice.invoice.seller_details.id))
             .await
             .change_context(InvoicingRenderError::StoreError)?;
 
@@ -120,7 +117,7 @@ impl PdfRenderingService {
         let invoicing_entity_ids = invoices
             .iter()
             .map(|invoice| invoice.seller_details.id)
-            .collect::<Vec<Uuid>>();
+            .collect::<Vec<InvoicingEntityId>>();
 
         let invoicing_entities = self
             .store

--- a/modules/meteroid/src/workers/kafka/outbox.rs
+++ b/modules/meteroid/src/workers/kafka/outbox.rs
@@ -1,4 +1,4 @@
-use common_domain::ids::TenantId;
+use common_domain::ids::{EventId, TenantId};
 use meteroid_store::domain::outbox_event::{CustomerEvent, InvoiceEvent, SubscriptionEvent};
 use rdkafka::message::{BorrowedHeaders, BorrowedMessage, Headers};
 use rdkafka::Message;
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 #[derive(Debug)]
 pub struct OutboxEvent {
-    pub id: String,
+    pub id: EventId,
     pub tenant_id: TenantId,
     pub aggregate_id: String,
     pub event_type: EventType,
@@ -56,7 +56,7 @@ impl EventType {
 /// todo return Result<Option<OutboxEvent>, Error>
 pub(crate) fn parse_outbox_event(m: &BorrowedMessage<'_>) -> Option<OutboxEvent> {
     let headers = m.headers()?;
-    let id = headers.get_as_string("local_id")?;
+    let id: EventId = headers.get_as_uuid("id")?.into();
     let tenant_id: TenantId = headers.get_as_uuid("tenant_id")?.into();
 
     let aggregate_id: String = String::from_utf8(m.key()?.to_vec()).ok()?;

--- a/modules/meteroid/src/workers/kafka/webhook.rs
+++ b/modules/meteroid/src/workers/kafka/webhook.rs
@@ -212,7 +212,7 @@ impl TryInto<Option<WebhookOutMessageNew>> for OutboxEvent {
         };
 
         let webhook = WebhookOutMessageNew {
-            id: self.id,
+            id: self.id.to_string(),
             event_type,
             payload,
         };

--- a/modules/meteroid/tests/data/0_minimal.sql
+++ b/modules/meteroid/tests/data/0_minimal.sql
@@ -47,10 +47,10 @@ $$
 
 
     INSERT INTO public.invoicing_entity
-    (id, local_id, is_default, legal_name, invoice_number_pattern, next_invoice_number, next_credit_note_number,
+    (id, is_default, legal_name, invoice_number_pattern, next_invoice_number, next_credit_note_number,
      grace_period_hours, net_terms, invoice_footer_info, invoice_footer_legal, logo_attachment_id, brand_color,
      address_line1, address_line2, zip_code, state, city, vat_number, country, accounting_currency, tenant_id)
-    VALUES (var_invoicing_entity_id, 'ive_O0sddA9FDlfeq', true, 'ACME_UK', 'INV-{number}', 1, 1, 23, 30, 'hello',
+    VALUES (var_invoicing_entity_id, true, 'ACME_UK', 'INV-{number}', 1, 1, 23, 30, 'hello',
             'world', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'FE', 'EUR', var_tenant_id);
 
 

--- a/modules/meteroid/tests/data/1_meters.sql
+++ b/modules/meteroid/tests/data/1_meters.sql
@@ -14,8 +14,8 @@ $$
 --
 
     INSERT INTO public.product_family
-      (id, name, local_id, created_at, updated_at, archived_at, tenant_id)
-    VALUES (var_product_family_id, 'Default', 'default', '2023-12-02 21:49:42.255', NULL, NULL, var_tenant_id);
+      (id, name, created_at, updated_at, archived_at, tenant_id)
+    VALUES (var_product_family_id, 'Default', '2023-12-02 21:49:42.255', NULL, NULL, var_tenant_id);
 
 
     --

--- a/modules/meteroid/tests/data/2_plans.sql
+++ b/modules/meteroid/tests/data/2_plans.sql
@@ -34,10 +34,10 @@ $$
 
     INSERT INTO public.plan
     (id, name, description, created_at, created_by, updated_at, archived_at, tenant_id,
-     product_family_id, local_id, plan_type, status, active_version_id, draft_version_id)
+     product_family_id, plan_type, status, active_version_id, draft_version_id)
     VALUES (var_plan_leetcode_id, 'LeetCode', '', '2023-12-04 10:05:45',
             var_user_id, NULL, NULL, var_tenant_id,
-            var_product_family_id, 'default_leet-code', 'STANDARD', 'ACTIVE', NULL, NULL);
+            var_product_family_id, 'STANDARD', 'ACTIVE', NULL, NULL);
 
     INSERT INTO public.plan_version
     VALUES (var_plan_version_1_leetcode_id, false, var_plan_leetcode_id, 1, NULL, NULL,
@@ -88,7 +88,7 @@ $$
     INSERT INTO public.plan
     VALUES (var_plan_notion_id, 'Notion', '', '2023-12-04 10:07:15.589',
             var_user_id, NULL, NULL, var_tenant_id,
-            var_product_family_id, 'default_notion', 'STANDARD', 'ACTIVE');
+            var_product_family_id, 'STANDARD', 'ACTIVE');
 
     INSERT INTO public.plan_version
     VALUES (var_plan_version_notion_id, false, var_plan_notion_id, 1, NULL, NULL,
@@ -140,7 +140,7 @@ $$
     INSERT INTO public.plan
     VALUES (var_plan_supabase_id, 'Supabase', '', '2023-12-04 10:08:53.591',
             var_user_id, NULL, NULL, var_tenant_id,
-            var_product_family_id, 'default_supabase', 'STANDARD', 'ACTIVE');
+            var_product_family_id, 'STANDARD', 'ACTIVE');
 
     INSERT INTO public.plan_version
     VALUES (var_plan_version_supabase_id, false, var_plan_supabase_id, 3, NULL, NULL,

--- a/modules/meteroid/tests/integration/e2e.rs
+++ b/modules/meteroid/tests/integration/e2e.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use crate::metering_it;
 use crate::{helpers, meteroid_it};
 use chrono::{Datelike, Days, Months};
-use common_domain::ids::TenantId;
+use common_domain::ids::{BaseId, InvoicingEntityId, TenantId};
 use metering_grpc::meteroid::metering::v1::{event::CustomerId, Event, IngestRequest};
 use meteroid::clients::usage::MeteringUsageClient;
 use meteroid::mapping::common::chrono_to_date;
@@ -489,7 +489,7 @@ async fn test_metering_e2e() {
                 snapshot_at: period_2_start.naive_utc(),
             },
             seller_details: InlineInvoicingEntity {
-                id: Uuid::now_v7(),
+                id: InvoicingEntityId::new(),
                 legal_name: "".to_string(),
                 vat_number: None,
                 address: Address {

--- a/modules/meteroid/tests/integration/test_slot_transaction.rs
+++ b/modules/meteroid/tests/integration/test_slot_transaction.rs
@@ -113,7 +113,7 @@ async fn create_slot_transaction(
         .add_slot_transaction(
             TENANT_ID.into(),
             SLOT_SUBSCRIPTION_ID.into(),
-            SLOT_PRICE_COMPONENT_ID,
+            SLOT_PRICE_COMPONENT_ID.into(),
             delta,
         )
         .await
@@ -125,7 +125,7 @@ async fn get_active_slots(store: &Store, timestamp: NaiveDateTime) -> u32 {
         .get_current_slots_value(
             TENANT_ID.into(),
             SLOT_SUBSCRIPTION_ID.into(),
-            SLOT_PRICE_COMPONENT_ID,
+            SLOT_PRICE_COMPONENT_ID.into(),
             Some(timestamp),
         )
         .await

--- a/modules/meteroid/tests/integration/test_subscription.rs
+++ b/modules/meteroid/tests/integration/test_subscription.rs
@@ -544,7 +544,7 @@ async fn test_subscription_create_invoice_seats() {
         .get_current_slots_value(
             db_invoice.tenant_id,
             subscription_id.into(),
-            price_component_id,
+            price_component_id.into(),
             Some(NaiveDateTime::from_str("2023-01-01T02:00:00").unwrap()),
         )
         .await

--- a/spec/api/v1/openapi.json
+++ b/spec/api/v1/openapi.json
@@ -976,7 +976,7 @@
             ]
           },
           "invoicing_entity_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/InvoicingEntityId"
           },
           "name": {
             "type": "string"
@@ -1042,9 +1042,13 @@
             ]
           },
           "invoicing_entity_id": {
-            "type": [
-              "string",
-              "null"
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InvoicingEntityId"
+              }
             ]
           },
           "name": {
@@ -1115,7 +1119,7 @@
             ]
           },
           "invoicing_entity_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/InvoicingEntityId"
           },
           "name": {
             "type": "string"
@@ -1137,6 +1141,9 @@
             ]
           }
         }
+      },
+      "InvoicingEntityId": {
+        "type": "string"
       },
       "PaginatedResponse_Customer": {
         "type": "object",
@@ -1196,7 +1203,7 @@
                   ]
                 },
                 "invoicing_entity_id": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/InvoicingEntityId"
                 },
                 "name": {
                   "type": "string"
@@ -1269,7 +1276,7 @@
                   "type": "boolean"
                 },
                 "id": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/PlanId"
                 },
                 "name": {
                   "type": "string"
@@ -1278,7 +1285,7 @@
                   "$ref": "#/components/schemas/PlanTypeEnum"
                 },
                 "product_family_id": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ProductFamilyId"
                 },
                 "product_family_name": {
                   "type": "string"
@@ -1326,7 +1333,7 @@
               ],
               "properties": {
                 "id": {
-                  "type": "string"
+                  "$ref": "#/components/schemas/ProductFamilyId"
                 },
                 "name": {
                   "type": "string"
@@ -1430,7 +1437,7 @@
             "type": "boolean"
           },
           "id": {
-            "type": "string"
+            "$ref": "#/components/schemas/PlanId"
           },
           "name": {
             "type": "string"
@@ -1439,7 +1446,7 @@
             "$ref": "#/components/schemas/PlanTypeEnum"
           },
           "product_family_id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ProductFamilyId"
           },
           "product_family_name": {
             "type": "string"
@@ -1455,6 +1462,9 @@
             "format": "int64"
           }
         }
+      },
+      "PlanId": {
+        "type": "string"
       },
       "PlanStatusEnum": {
         "type": "string",
@@ -1481,7 +1491,7 @@
         ],
         "properties": {
           "id": {
-            "type": "string"
+            "$ref": "#/components/schemas/ProductFamilyId"
           },
           "name": {
             "type": "string"
@@ -1498,6 +1508,9 @@
             "type": "string"
           }
         }
+      },
+      "ProductFamilyId": {
+        "type": "string"
       },
       "ShippingAddress": {
         "type": "object",


### PR DESCRIPTION
## Description
Removed local_id from the database. We use custom ids: uuid that are base62 encoded and are prefixed.
Note: the grpc API still has local_id but it is populated by the backend as custom_id. We will remove local_ids from grpc API as soon as frontend migrates to use the id.

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
