### PR TITLE
chore: rotate encoded ids bytes to break timestamp prefix

### DIFF
--- a/crates/common-domain/src/ids/macros.rs
+++ b/crates/common-domain/src/ids/macros.rs
@@ -83,6 +83,7 @@ macro_rules! id_type {
                     .and_then(|s| {
                         base62::decode(s)
                             .map_err(|e| $crate::ids::IdError(e.to_string()))
+                            .map(|decoded| decoded.rotate_right(67))
                             .map(uuid::Uuid::from_u128)
                             .map($id_name)
                     })

--- a/crates/common-domain/src/ids/mod.rs
+++ b/crates/common-domain/src/ids/mod.rs
@@ -50,11 +50,10 @@ pub trait BaseId: Deref<Target = Uuid> {
     fn parse_uuid(s: &str) -> Result<Self::IdType, IdError>;
 
     fn as_base62(&self) -> String {
-        format!(
-            "{}{}",
-            Self::PREFIX,
-            base62::encode(self.as_uuid().as_u128())
-        )
+        let original = self.as_uuid().as_u128();
+        let rotated = original.rotate_left(67); // avoids similar-looking ids with the timestamp in first characters
+
+        format!("{}{}", Self::PREFIX, base62::encode(rotated))
     }
 
     fn parse_base62(s: &str) -> Result<Self::IdType, IdError>;


### PR DESCRIPTION
just to be able to differentiate easily 2 ids of the same type, and to allow shortened with ellipsis display 