### PR TITLE
chore: improve pennylane oauth

### DIFF
--- a/modules/meteroid/crates/diesel-models/src/connectors.rs
+++ b/modules/meteroid/crates/diesel-models/src/connectors.rs
@@ -37,4 +37,5 @@ pub struct ConnectorRowNew {
 pub struct ConnectorRowPatch {
     pub id: ConnectorId,
     pub data: Option<Option<serde_json::Value>>,
+    pub sensitive: Option<Option<String>>,
 }

--- a/modules/meteroid/crates/meteroid-oauth/src/config.rs
+++ b/modules/meteroid/crates/meteroid-oauth/src/config.rs
@@ -61,10 +61,22 @@ pub struct HubspotOauthConfig {
     pub client_secret: Option<SecretString>,
 }
 
+impl HubspotOauthConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.client_id.is_some() && self.client_secret.is_some()
+    }
+}
+
 #[derive(Envconfig, Debug, Clone)]
 pub struct PennylaneOauthConfig {
     #[envconfig(from = "OAUTH_PENNYLANE_CLIENT_ID")]
     pub client_id: Option<SecretString>,
     #[envconfig(from = "OAUTH_PENNYLANE_CLIENT_SECRET")]
     pub client_secret: Option<SecretString>,
+}
+
+impl PennylaneOauthConfig {
+    pub fn is_enabled(&self) -> bool {
+        self.client_id.is_some() && self.client_secret.is_some()
+    }
 }

--- a/modules/meteroid/crates/meteroid-oauth/src/model.rs
+++ b/modules/meteroid/crates/meteroid-oauth/src/model.rs
@@ -49,27 +49,20 @@ pub struct AuthorizeUrl {
 }
 
 #[derive(Debug, Clone)]
-pub struct OauthAccessToken {
-    pub value: SecretString,
-    pub expires_in: Option<Duration>,
-}
-
-#[derive(Debug, Clone)]
 pub struct OAuthTokens {
-    pub access_token: OauthAccessToken,
+    pub access_token: SecretString,
     pub refresh_token: Option<SecretString>,
+    pub expires_in: Option<Duration>,
 }
 
 impl From<BasicTokenResponse> for OAuthTokens {
     fn from(response: BasicTokenResponse) -> Self {
         OAuthTokens {
-            access_token: OauthAccessToken {
-                value: SecretString::new(response.access_token().secret().to_owned()),
-                expires_in: response.expires_in(),
-            },
+            access_token: SecretString::new(response.access_token().secret().to_owned()),
             refresh_token: response
                 .refresh_token()
                 .map(|t| SecretString::new(t.secret().to_owned())),
+            expires_in: response.expires_in(),
         }
     }
 }

--- a/modules/meteroid/crates/meteroid-store/src/repositories/oauth.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/oauth.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use chrono::Utc;
 use diesel_models::oauth_verifiers::OauthVerifierRow;
 use error_stack::{Report, ResultExt};
-use meteroid_oauth::model::{OauthAccessToken, OauthProvider};
+use meteroid_oauth::model::{OAuthTokens, OauthProvider};
 use secrecy::{ExposeSecret, SecretString};
 use std::ops::Sub;
 
@@ -35,7 +35,7 @@ pub trait OauthInterface {
         &self,
         provider: OauthProvider,
         refresh_token: SecretString,
-    ) -> StoreResult<OauthAccessToken>;
+    ) -> StoreResult<OAuthTokens>;
 }
 
 #[async_trait]
@@ -93,7 +93,7 @@ impl OauthInterface for Store {
             ))?;
 
         let user = srv
-            .get_user_info(tokens.access_token.value)
+            .get_user_info(tokens.access_token)
             .await
             .change_context(StoreError::OauthError(
                 "Failed to fetch oauth user".to_owned(),
@@ -133,7 +133,7 @@ impl OauthInterface for Store {
         &self,
         provider: OauthProvider,
         refresh_token: SecretString,
-    ) -> StoreResult<OauthAccessToken> {
+    ) -> StoreResult<OAuthTokens> {
         self.oauth
             .for_provider(provider)
             .ok_or(Report::new(StoreError::OauthError(

--- a/modules/meteroid/src/workers/mod.rs
+++ b/modules/meteroid/src/workers/mod.rs
@@ -88,17 +88,25 @@ pub async fn spawn_workers(
         });
     }
     {
-        let store = store.clone();
-        join_set.spawn(async move {
-            processors::run_hubspot_sync(store, hubspot_client).await;
-        });
+        if config.oauth.hubspot.is_enabled() {
+            let store = store.clone();
+            join_set.spawn(async move {
+                processors::run_hubspot_sync(store, hubspot_client).await;
+            });
+        } else {
+            log::warn!("Hubspot OAuth is not configured, skipping Hubspot sync worker.");
+        }
     }
     {
-        let store = store.clone();
-        let object_store_service = object_store_service.clone();
-        join_set.spawn(async move {
-            processors::run_pennylane_sync(store, pennylane_client, object_store_service).await;
-        });
+        if config.oauth.pennylane.is_enabled() {
+            let store = store.clone();
+            let object_store_service = object_store_service.clone();
+            join_set.spawn(async move {
+                processors::run_pennylane_sync(store, pennylane_client, object_store_service).await;
+            });
+        } else {
+            log::warn!("Pennylane OAuth is not configured, skipping Pennylane sync worker.");
+        }
     }
     {
         let store = store.clone();


### PR DESCRIPTION
## Description
 - store access_token along with refresh_token. seems like you can use a single time the refresh token to get an access token

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
