### PR TITLE
fix: Improvements to docker-compose file for local deployment

### DIFF
--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -238,6 +238,7 @@ services:
     environment:
       - INTERNAL_API_SECRET=${INTERNAL_API_SECRET}
       - METERING_API_LISTEN_ADDRESS=0.0.0.0:50062
+      - METEROID_API_EXTERNAL_URL=http://meteroid-api:50061
       - KAFKA_BOOTSTRAP_SERVERS=redpanda:29092
       - KAFKA_RAW_TOPIC=${KAFKA_RAW_TOPIC:-meteroid-events-raw}
       - CLICKHOUSE_DATABASE=${CLICKHOUSE_DATABASE:-meteroid}

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -46,6 +46,21 @@ services:
       - meteroid_net
     logging: *logging
 
+  # Ensure clickhouse_coordination folders are setup with the correct user permissions
+  # clickhouse-server seems to use uid:gid -> 101:101, and default volume permissions are based on root
+  clickhouse-volume-init:
+    image: alpine:3.21
+    user: root
+    command:
+      - sh
+      - -c
+      - mkdir -p /coordination/log /coordination/snapshots && chown -R 101:101
+        /coordination
+    volumes:
+      - clickhouse_coordination:/coordination
+    restart: "no"
+    logging: *logging
+
   clickhouse:
     image: clickhouse/clickhouse-server:25.6.2-alpine
     ports:

--- a/docker/deploy/docker-compose.yml
+++ b/docker/deploy/docker-compose.yml
@@ -62,6 +62,9 @@ services:
     logging: *logging
 
   clickhouse:
+    depends_on:                                                                                                                                                                                                                        
+    clickhouse-volume-init:                                                                                                                                                                                                          
+      condition: service_completed_successfully                                                                                                                                                                                      
     image: clickhouse/clickhouse-server:25.6.2-alpine
     ports:
       - 8123:8123

--- a/docker/deploy/volume/clickhouse/config.xml
+++ b/docker/deploy/volume/clickhouse/config.xml
@@ -1,5 +1,5 @@
 <clickhouse>
-  <!-- Ensure clickhous logs errors to stdout, instad of to an error file. Error files in exited containers are difficult to debug -->
+  <!-- Ensure clickhouse logs errors to stdout, instad of to an error file. Error files in exited containers are difficult to debug -->
   <!-- Uncomment to enable logging to stdout for debugging -->
   <!-- logger>
       <log>/dev/null</log>

--- a/docker/deploy/volume/clickhouse/config.xml
+++ b/docker/deploy/volume/clickhouse/config.xml
@@ -1,10 +1,11 @@
 <clickhouse>
   <!-- Ensure clickhous logs errors to stdout, instad of to an error file. Error files in exited containers are difficult to debug -->
-  <logger>
-    <log>/dev/null</log>
-    <errorlog>/dev/null</errorlog>
-    <console>1</console>
-  </logger>
+  <!-- Uncomment to enable logging to stdout for debugging -->
+  <!-- logger>
+      <log>/dev/null</log>
+      <errorlog>/dev/null</errorlog>
+      <console>1</console>
+  </logger -->
   <!-- Embedded Keeper (single node, no separate ZooKeeper needed) -->
   <keeper_server>
     <tcp_port>9181</tcp_port>

--- a/docker/deploy/volume/clickhouse/config.xml
+++ b/docker/deploy/volume/clickhouse/config.xml
@@ -1,4 +1,10 @@
 <clickhouse>
+  <!-- Ensure clickhous logs errors to stdout, instad of to an error file. Error files in exited containers are difficult to debug -->
+  <logger>
+    <log>/dev/null</log>
+    <errorlog>/dev/null</errorlog>
+    <console>1</console>
+  </logger>
   <!-- Embedded Keeper (single node, no separate ZooKeeper needed) -->
   <keeper_server>
     <tcp_port>9181</tcp_port>


### PR DESCRIPTION
## Description
I wanted to setup meteroid locally for integration and development since I needed to send webhooks to a localhost api. I found out clickhouse and by extension the metering api wouldn't start.

It seems clickhouse runs as a specific uid:gid combination (101:101), and docker-compose volumes are setup with root permissions. I added an init container that ensures the required clickhouse folders are created with the correct user permissions.

I am using WSL2 integration with docker-desktop, though I would assume this problem exists also on native docker on linux.

Also: The metering-api was set to try to connect to the meteroid-api at `http://127.0.0:50061`. Since its running in a docker network the connection should be `http://meteroid-api:50061` instead.

## Checklist
- [X] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [X] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [X] I have self-reviewed my code and ensured its quality.
- [X] I have added/updated necessary comments to aid understanding.
