### PR TITLE
fix: Entitlements issues #2

### DIFF
--- a/modules/meteroid/crates/meteroid-store/src/domain/entitlements.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/entitlements.rs
@@ -327,7 +327,6 @@ pub struct ResolvedOrigin {
 pub struct RawResolvedEntitlement {
     pub feature: FeatureRef,
     pub value: ResolvedEntitlementValue,
-    pub created_at: DateTime<Utc>,
     /// Highest-priority entity that contributed to the final value. See
     /// [`ResolvedEntitlement::origin`] for the resolution semantics.
     pub origin_entity: EntitlementEntityId,
@@ -340,8 +339,6 @@ pub struct RawResolvedEntitlement {
 pub struct ResolvedEntitlement {
     pub feature: FeatureRef,
     pub value: ResolvedEntitlementValue,
-    /// Earliest creation time across resolved entitlements. Used as default usage floor.
-    pub created_at: DateTime<Utc>,
     /// Highest-priority entity that contributed to the final value, with its display name.
     /// For Override winners this is the overriding entity; for Stack merges it is the
     /// highest-priority contributing entity. Feature-level (tenant default) returns
@@ -354,7 +351,6 @@ pub struct ResolvedEntitlement {
 pub struct EffectiveEntitlement {
     pub feature: FeatureRef,
     pub value: EffectiveEntitlementValue,
-    pub created_at: DateTime<Utc>,
     /// Highest-priority entity that contributed to the final value, with its human-readable name.
     /// For Override winners this is the overriding entity; for Stack merges it is the
     /// highest-priority contributing entity. Feature-level (tenant default) returns

--- a/modules/meteroid/crates/meteroid-store/src/repositories/entitlements.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/entitlements.rs
@@ -122,7 +122,7 @@ pub trait EntitlementsInterface {
     /// `Feature → Plan → AddOn → PlanVersion → Subscription`. Subscription-level grants
     /// always win; PlanVersion overrides its linked AddOns because the plan version is
     /// the authoritative composition. See [`EntitlementEntityId::priority`].
-    async fn get_effective_entitlements(
+    async fn resolve_entitlements_for_customer(
         &self,
         conn: &mut PgConn,
         customer_id: CustomerId,
@@ -131,7 +131,7 @@ pub trait EntitlementsInterface {
 
     /// Single-feature variant of [`get_effective_entitlements`].
     /// Returns `None` when the feature is outside the customer's product scope or yields no grants.
-    async fn get_effective_entitlements_for_feature(
+    async fn resolve_entitlements_for_feature(
         &self,
         conn: &mut PgConn,
         customer_id: CustomerId,
@@ -142,7 +142,7 @@ pub trait EntitlementsInterface {
     /// Resolve entitlements for a single target — product, add-on, plan version, subscription,
     /// quote, or in-flight `Selection` — used for per-entity previews in the UI.
     /// Returns one `ResolvedEntitlement` per feature in the target's product scope.
-    async fn resolve_for_entity(
+    async fn resolve_entitlements_for_entity(
         &self,
         conn: &mut PgConn,
         tenant_id: TenantId,
@@ -476,7 +476,7 @@ impl EntitlementsInterface for Store {
             .map_err(Into::into)
     }
 
-    async fn get_effective_entitlements(
+    async fn resolve_entitlements_for_customer(
         &self,
         conn: &mut PgConn,
         customer_id: CustomerId,
@@ -489,7 +489,7 @@ impl EntitlementsInterface for Store {
         .await
     }
 
-    async fn resolve_for_entity(
+    async fn resolve_entitlements_for_entity(
         &self,
         conn: &mut PgConn,
         tenant_id: TenantId,
@@ -507,7 +507,7 @@ impl EntitlementsInterface for Store {
         .await
     }
 
-    async fn get_effective_entitlements_for_feature(
+    async fn resolve_entitlements_for_feature(
         &self,
         conn: &mut PgConn,
         customer_id: CustomerId,
@@ -578,14 +578,12 @@ pub(crate) struct BillingCyclePeriod {
 pub(crate) fn compute_usage_period(
     reset_period: &ResetPeriod,
     billing_cycle: Option<BillingCyclePeriod>,
-    activation_date: Option<NaiveDate>,
+    activation_date: Option<NaiveDateTime>,
     now: NaiveDateTime,
 ) -> UsagePeriodBounds {
     match reset_period {
         ResetPeriod::Never => UsagePeriodBounds {
-            start: activation_date
-                .map(|d| d.and_time(NaiveTime::MIN))
-                .unwrap_or(now),
+            start: activation_date.unwrap_or(now),
             end: None,
         },
         ResetPeriod::BillingCycle => match billing_cycle {
@@ -603,7 +601,7 @@ pub(crate) fn compute_usage_period(
         },
         ResetPeriod::Calendar { unit, interval } => calendar_period(now, unit, *interval),
         ResetPeriod::FixedWindow { unit, interval } => match activation_date {
-            Some(act) => fixed_window(act.and_time(NaiveTime::MIN), now, unit, *interval),
+            Some(act) => fixed_window(act, now, unit, *interval),
             None => UsagePeriodBounds {
                 start: now,
                 end: None,
@@ -867,7 +865,6 @@ async fn with_origin_names(
         .map(|raw| ResolvedEntitlement {
             feature: raw.feature,
             value: raw.value,
-            created_at: raw.created_at,
             origin: ResolvedOrigin {
                 name: lookup(&raw.origin_entity),
                 entity: raw.origin_entity,
@@ -1452,14 +1449,9 @@ fn resolve(
 
         let mut accumulated: Option<EntitlementValue> = None;
         let mut accumulated_priority: Option<u8> = None;
-        let mut min_created_at: Option<DateTime<chrono::Utc>> = None;
         let mut winning_origin: Option<EntitlementEntityId> = None;
 
         for ent in ents {
-            min_created_at = Some(match min_created_at {
-                None => ent.created_at,
-                Some(prev) => prev.min(ent.created_at),
-            });
             let pri = ent.entity.priority();
             let same_priority = accumulated_priority == Some(pri);
             let is_additive = matches!(
@@ -1529,7 +1521,6 @@ fn resolve(
                 product: feature.product.clone(),
             },
             value: resolved_value,
-            created_at: min_created_at.expect("min_created_at set whenever accumulated is Some"),
             origin_entity: winning_origin.expect("origin set whenever accumulated is Some"),
         });
     }
@@ -2196,7 +2187,7 @@ mod tests {
     #[test]
     fn usage_period_never_uses_activation_date() {
         let now = dt(2025, 6, 15);
-        let activation = d(2024, 1, 1);
+        let activation = dt(2024, 1, 1);
         let b = compute_usage_period(&ResetPeriod::Never, None, Some(activation), now);
         assert_eq!(b.start, dt(2024, 1, 1));
         assert_eq!(b.end, None);
@@ -2300,7 +2291,7 @@ mod tests {
     #[test]
     fn usage_period_fixed_window_day_first_bucket_starts_at_activation() {
         // Activation 2025-06-10, 7-day buckets. `now` 2025-06-13 falls in bucket 0.
-        let activation = d(2025, 6, 10);
+        let activation = dt(2025, 6, 10);
         let now = dt(2025, 6, 13);
         let b = compute_usage_period(
             &ResetPeriod::FixedWindow {
@@ -2319,7 +2310,7 @@ mod tests {
     fn usage_period_fixed_window_day_advances_to_current_bucket() {
         // Activation 2025-06-10, 7-day buckets. `now` 2025-07-02 → bucket 3
         // (start 2025-07-01, end 2025-07-08).
-        let activation = d(2025, 6, 10);
+        let activation = dt(2025, 6, 10);
         let now = dt(2025, 7, 2);
         let b = compute_usage_period(
             &ResetPeriod::FixedWindow {
@@ -2338,7 +2329,7 @@ mod tests {
     fn usage_period_fixed_window_hour_anchored_on_activation() {
         // Activation midnight 2025-06-10, 6-hour buckets. `now` 2025-06-10 14:30
         // → bucket 2 (start 12:00, end 18:00).
-        let activation = d(2025, 6, 10);
+        let activation = dt(2025, 6, 10);
         let now = dt_hms(2025, 6, 10, 14, 30, 0);
         let b = compute_usage_period(
             &ResetPeriod::FixedWindow {
@@ -2354,9 +2345,26 @@ mod tests {
     }
 
     #[test]
+    fn usage_period_fixed_window_hour_anchored_on_activation_with_time() {
+        let activation = dt_hms(2025, 5, 27, 14, 10, 0);
+        let now = dt_hms(2025, 5, 27, 14, 20, 0);
+        let b = compute_usage_period(
+            &ResetPeriod::FixedWindow {
+                unit: PeriodUnit::Hour,
+                interval: 2,
+            },
+            None,
+            Some(activation),
+            now,
+        );
+        assert_eq!(b.start, dt_hms(2025, 5, 27, 14, 10, 0));
+        assert_eq!(b.end, Some(dt_hms(2025, 5, 27, 16, 10, 0)));
+    }
+
+    #[test]
     fn usage_period_fixed_window_month_advances_to_current_bucket() {
         // Activation 2025-01-15, 1-month buckets. `now` 2025-06-20 → bucket starts 2025-06-15.
-        let activation = d(2025, 1, 15);
+        let activation = dt(2025, 1, 15);
         let now = dt(2025, 6, 20);
         let b = compute_usage_period(
             &ResetPeriod::FixedWindow {
@@ -2374,7 +2382,7 @@ mod tests {
     #[test]
     fn usage_period_fixed_window_year_advances_to_current_bucket() {
         // Activation 2020-03-10, 1-year buckets. `now` 2025-06-15 → bucket starts 2025-03-10.
-        let activation = d(2020, 3, 10);
+        let activation = dt(2020, 3, 10);
         let now = dt(2025, 6, 15);
         let b = compute_usage_period(
             &ResetPeriod::FixedWindow {

--- a/modules/meteroid/crates/meteroid-store/src/services/clients/usage.rs
+++ b/modules/meteroid/crates/meteroid-store/src/services/clients/usage.rs
@@ -84,6 +84,14 @@ pub trait UsageClient: Send + Sync {
         period: UsagePeriod,
     ) -> StoreResult<UsageData>;
 
+    async fn fetch_total_usage(
+        &self,
+        tenant_id: &TenantId,
+        customer_id: &CustomerId,
+        metric: &BillableMetric,
+        period: UsagePeriod,
+    ) -> StoreResult<Decimal>;
+
     async fn fetch_windowed_usage(
         &self,
         tenant_id: &TenantId,
@@ -148,6 +156,25 @@ impl UsageClient for MockUsageClient {
                 period: period.clone(),
             });
         Ok(usage_data)
+    }
+
+    async fn fetch_total_usage(
+        &self,
+        _tenant_id: &TenantId,
+        _customer_id: &CustomerId,
+        metric: &BillableMetric,
+        period: UsagePeriod,
+    ) -> StoreResult<Decimal> {
+        let params = MockUsageDataParams {
+            metric_id: metric.id,
+            period_start: period.start,
+            period_end: period.end,
+        };
+        Ok(self
+            .data
+            .get(&params)
+            .map(|d| d.data.iter().map(|g| g.value).sum())
+            .unwrap_or(Decimal::ZERO))
     }
 
     async fn fetch_windowed_usage(

--- a/modules/meteroid/crates/meteroid-store/src/services/entitlements.rs
+++ b/modules/meteroid/crates/meteroid-store/src/services/entitlements.rs
@@ -3,16 +3,16 @@ use crate::domain::entitlements::{
     EffectiveEntitlement, EffectiveEntitlementValue, EntitlementUsage, FeatureRef, OverageBehavior,
     ResetPeriod, ResolvedEntitlement, ResolvedEntitlementValue, ResolvedOrigin,
 };
-use crate::domain::enums::BillingMetricAggregateEnum;
 use crate::domain::{BillableMetric, UsagePeriod};
 use crate::errors::StoreError;
 use crate::repositories::EntitlementsInterface;
-use crate::repositories::entitlements::{BillingCyclePeriod, compute_usage_period};
+use crate::repositories::entitlements::{BillingCyclePeriod, ResolveTarget, compute_usage_period};
+use crate::repositories::subscriptions::SubscriptionInterface;
 use crate::services::Services;
-use crate::services::clients::usage::GroupedUsageData;
+
 use crate::store::PgConn;
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use common_domain::ids::{BillableMetricId, CustomerId, FeatureId, TenantId};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use common_domain::ids::{BillableMetricId, CustomerId, FeatureId, SubscriptionId, TenantId};
 use diesel_models::billable_metrics::BillableMetricRow;
 use diesel_models::subscriptions::SubscriptionRow;
 use error_stack::Report;
@@ -26,10 +26,8 @@ static USAGE_FETCH_CONCURRENCY: usize = 8;
 
 struct MeteredMeta {
     feature: FeatureRef,
-    created_at: DateTime<Utc>,
     origin: ResolvedOrigin,
     metric_id: BillableMetricId,
-    aggregation_type: BillingMetricAggregateEnum,
     limit: Option<Decimal>,
     reset_period: ResetPeriod,
     overage_behavior: OverageBehavior,
@@ -50,7 +48,7 @@ impl Services {
         let resolved = {
             let mut conn = self.store.get_conn().await?;
             self.store
-                .get_effective_entitlements(&mut conn, customer_id, tenant_id)
+                .resolve_entitlements_for_customer(&mut conn, customer_id, tenant_id)
                 .await?
         };
         self.enrich_with_usage(customer_id, tenant_id, resolved)
@@ -66,12 +64,7 @@ impl Services {
         let resolved = {
             let mut conn = self.store.get_conn().await?;
             self.store
-                .get_effective_entitlements_for_feature(
-                    &mut conn,
-                    customer_id,
-                    tenant_id,
-                    feature_id,
-                )
+                .resolve_entitlements_for_feature(&mut conn, customer_id, tenant_id, feature_id)
                 .await?
         };
         let target: Vec<ResolvedEntitlement> = resolved.into_iter().collect::<Vec<_>>();
@@ -81,11 +74,79 @@ impl Services {
         Ok(enriched.pop())
     }
 
+    pub(crate) async fn get_effective_entitlements_for_subscription(
+        &self,
+        subscription_id: SubscriptionId,
+        tenant_id: TenantId,
+    ) -> StoreResult<Vec<EffectiveEntitlement>> {
+        let sub = self
+            .store
+            .get_subscription(tenant_id, subscription_id)
+            .await?;
+        let resolved = {
+            let mut conn = self.store.get_conn().await?;
+            self.store
+                .resolve_entitlements_for_entity(
+                    &mut conn,
+                    tenant_id,
+                    ResolveTarget::Subscription(subscription_id),
+                )
+                .await?
+        };
+        let billing_cycle_period = Some(BillingCyclePeriod {
+            period_start: sub.current_period_start,
+            period_end: sub.current_period_end,
+        });
+        self.enrich_with_context(
+            sub.customer_id,
+            tenant_id,
+            resolved,
+            billing_cycle_period,
+            sub.activated_at,
+        )
+        .await
+    }
+
     async fn enrich_with_usage(
         &self,
         customer_id: CustomerId,
         tenant_id: TenantId,
         resolved: Vec<ResolvedEntitlement>,
+    ) -> StoreResult<Vec<EffectiveEntitlement>> {
+        let metric_ids: Vec<BillableMetricId> = resolved
+            .iter()
+            .filter_map(|e| match &e.value {
+                ResolvedEntitlementValue::Metered { metric_id, .. } => Some(*metric_id),
+                ResolvedEntitlementValue::Boolean { .. } => None,
+            })
+            .unique()
+            .collect();
+
+        let (billing_cycle_period, activation_date) = if metric_ids.is_empty() {
+            (None, None)
+        } else {
+            let mut conn = self.store.get_conn().await?;
+            self.load_billing_context(&mut conn, customer_id, tenant_id)
+                .await?
+        };
+
+        self.enrich_with_context(
+            customer_id,
+            tenant_id,
+            resolved,
+            billing_cycle_period,
+            activation_date,
+        )
+        .await
+    }
+
+    async fn enrich_with_context(
+        &self,
+        customer_id: CustomerId,
+        tenant_id: TenantId,
+        resolved: Vec<ResolvedEntitlement>,
+        billing_cycle_period: Option<BillingCyclePeriod>,
+        activation_date: Option<NaiveDateTime>,
     ) -> StoreResult<Vec<EffectiveEntitlement>> {
         if resolved.is_empty() {
             return Ok(vec![]);
@@ -102,21 +163,10 @@ impl Services {
             .unique()
             .collect();
 
-        // Acquire a connection only for the local DB lookups (billing context + metric
-        // metadata), then drop it before the HTTP fan-out so the pool isn't tied up while
-        // waiting on the metering backend.
-        let (billing_cycle_period, activation_date, metrics) = {
+        let metrics = {
             let mut conn = self.store.get_conn().await?;
-            let (bc, ad) = if metric_ids.is_empty() {
-                (None, None)
-            } else {
-                self.load_billing_context(&mut conn, customer_id, tenant_id)
-                    .await?
-            };
-            let metrics = self
-                .load_metrics(&mut conn, &metric_ids, &tenant_id)
-                .await?;
-            (bc, ad, metrics)
+            self.load_metrics(&mut conn, &metric_ids, &tenant_id)
+                .await?
         };
 
         let mut result: Vec<EffectiveEntitlement> = Vec::with_capacity(resolved.len());
@@ -128,7 +178,6 @@ impl Services {
                 ResolvedEntitlementValue::Boolean { enabled } => {
                     result.push(EffectiveEntitlement {
                         feature: ent.feature,
-                        created_at: ent.created_at,
                         origin: ent.origin,
                         value: EffectiveEntitlementValue::Boolean { enabled },
                     });
@@ -149,7 +198,6 @@ impl Services {
                         );
                         result.push(build_unavailable_metered_entitlement(
                             ent.feature,
-                            ent.created_at,
                             ent.origin,
                             metric_id,
                             limit,
@@ -172,10 +220,8 @@ impl Services {
                     let reset_at = bounds.end.map(|t| t.and_utc());
                     let meta = MeteredMeta {
                         feature: ent.feature,
-                        created_at: ent.created_at,
                         origin: ent.origin,
                         metric_id,
-                        aggregation_type: metric.aggregation_type,
                         limit,
                         reset_period,
                         overage_behavior,
@@ -192,7 +238,7 @@ impl Services {
                         continue;
                     }
 
-                    usage_futs.push(self.usage_client.fetch_usage(
+                    usage_futs.push(self.usage_client.fetch_total_usage(
                         &tenant_id,
                         &customer_id,
                         metric,
@@ -211,8 +257,7 @@ impl Services {
             .try_collect()
             .await?;
 
-        for (meta, usage_data) in metered_meta.into_iter().zip(usage_results) {
-            let consumed = reduce_usage(&usage_data.data, meta.aggregation_type);
+        for (meta, consumed) in metered_meta.into_iter().zip(usage_results) {
             result.push(build_metered_entitlement(meta, consumed));
         }
 
@@ -224,7 +269,7 @@ impl Services {
         conn: &mut PgConn,
         customer_id: CustomerId,
         tenant_id: TenantId,
-    ) -> StoreResult<(Option<BillingCyclePeriod>, Option<NaiveDate>)> {
+    ) -> StoreResult<(Option<BillingCyclePeriod>, Option<NaiveDateTime>)> {
         let sub_rows = SubscriptionRow::find_active_by_customer(conn, customer_id, tenant_id)
             .await
             .map_err(Into::<Report<StoreError>>::into)?;
@@ -242,10 +287,7 @@ impl Services {
                     period_end: r.current_period_end,
                 });
 
-        let activation_date = sub_rows
-            .iter()
-            .filter_map(|r| r.activated_at.map(|dt| dt.date()))
-            .min();
+        let activation_date = sub_rows.iter().filter_map(|r| r.activated_at).min();
 
         Ok((billing_cycle_period, activation_date))
     }
@@ -272,50 +314,12 @@ impl Services {
     }
 }
 
-/// Fold a metric's grouped usage rows into the single `consumed` number reported on the
-/// effective entitlement.
-///
-/// Each [`GroupedUsageData`] is already pre-aggregated by the metering backend for one
-/// dimension group (e.g. one region). This function combines those per-group values:
-///
-/// - `Sum` / `Count` / `CountDistinct` — sum the group values; the natural total across
-///   dimensions.
-/// - `Latest` — also summed across groups. `GroupedUsageData` has no per-group timestamp,
-///   so we cannot pick the temporally-latest single group; summing the per-group latest
-///   gives the current total (e.g. latest queue depth across regions).
-/// - `Max` / `Min` — pick across group values.
-/// - `Mean` — mean of per-group totals, **not** mean per event. For a metric with one
-///   dimension group this equals `Sum`. Callers wanting per-event mean must aggregate
-///   that way at the metering layer.
-fn reduce_usage(
-    data: &[GroupedUsageData],
-    aggregation_type: BillingMetricAggregateEnum,
-) -> Decimal {
-    let values = || data.iter().map(|g| g.value);
-    match aggregation_type {
-        BillingMetricAggregateEnum::Sum
-        | BillingMetricAggregateEnum::Count
-        | BillingMetricAggregateEnum::CountDistinct
-        | BillingMetricAggregateEnum::Latest => values().sum(),
-        BillingMetricAggregateEnum::Max => values().reduce(Decimal::max).unwrap_or(Decimal::ZERO),
-        BillingMetricAggregateEnum::Min => values().reduce(Decimal::min).unwrap_or(Decimal::ZERO),
-        BillingMetricAggregateEnum::Mean => {
-            if data.is_empty() {
-                Decimal::ZERO
-            } else {
-                values().sum::<Decimal>() / Decimal::from(data.len())
-            }
-        }
-    }
-}
-
 fn build_metered_entitlement(meta: MeteredMeta, consumed: Decimal) -> EffectiveEntitlement {
     let remaining = meta.limit.map(|l| (l - consumed).max(Decimal::ZERO));
     // Auto-disable when usage has reached or exceeded the limit.
     let enabled = meta.enabled && meta.limit.is_none_or(|l| consumed < l);
     EffectiveEntitlement {
         feature: meta.feature,
-        created_at: meta.created_at,
         origin: meta.origin,
         value: EffectiveEntitlementValue::Metered {
             metric_id: meta.metric_id,
@@ -339,7 +343,6 @@ fn build_metered_entitlement(meta: MeteredMeta, consumed: Decimal) -> EffectiveE
 #[allow(clippy::too_many_arguments)]
 fn build_unavailable_metered_entitlement(
     feature: FeatureRef,
-    created_at: DateTime<Utc>,
     origin: ResolvedOrigin,
     metric_id: BillableMetricId,
     limit: Option<Decimal>,
@@ -350,7 +353,6 @@ fn build_unavailable_metered_entitlement(
 ) -> EffectiveEntitlement {
     EffectiveEntitlement {
         feature,
-        created_at,
         origin,
         value: EffectiveEntitlementValue::Metered {
             metric_id,
@@ -374,13 +376,6 @@ mod tests {
     use super::*;
     use common_domain::ids::BaseId;
 
-    fn group(value: f64) -> GroupedUsageData {
-        GroupedUsageData {
-            value: Decimal::try_from(value).unwrap(),
-            dimensions: std::collections::HashMap::new(),
-        }
-    }
-
     fn meta(limit: Option<f64>, period_start: NaiveDateTime) -> MeteredMeta {
         MeteredMeta {
             feature: FeatureRef {
@@ -388,13 +383,11 @@ mod tests {
                 name: "test".to_string(),
                 product: None,
             },
-            created_at: Utc::now(),
             origin: ResolvedOrigin {
                 entity: common_domain::ids::EntitlementEntityId::Feature(FeatureId::new()),
                 name: None,
             },
             metric_id: BillableMetricId::new(),
-            aggregation_type: BillingMetricAggregateEnum::Sum,
             limit: limit.map(|v| Decimal::try_from(v).unwrap()),
             reset_period: ResetPeriod::Never,
             overage_behavior: OverageBehavior::Block {
@@ -404,106 +397,6 @@ mod tests {
             enabled: true,
             period_start,
             reset_at: None,
-        }
-    }
-
-    // --- reduce_usage ---
-
-    #[test]
-    fn reduce_sum_adds_groups() {
-        let data = vec![group(10.0), group(20.0), group(30.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Sum),
-            Decimal::from(60)
-        );
-    }
-
-    #[test]
-    fn reduce_count_adds_groups() {
-        let data = vec![group(5.0), group(3.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Count),
-            Decimal::from(8)
-        );
-    }
-
-    #[test]
-    fn reduce_count_distinct_adds_groups() {
-        let data = vec![group(100.0), group(50.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::CountDistinct),
-            Decimal::from(150)
-        );
-    }
-
-    #[test]
-    fn reduce_max_takes_largest() {
-        let data = vec![group(10.0), group(30.0), group(20.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Max),
-            Decimal::from(30)
-        );
-    }
-
-    #[test]
-    fn reduce_latest_sums_groups() {
-        // Each GroupedUsageData already holds the per-group latest value. Across groups
-        // we sum (e.g. latest queue depth per region → total queue depth).
-        let data = vec![group(5.0), group(15.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Latest),
-            Decimal::from(20)
-        );
-    }
-
-    #[test]
-    fn reduce_max_preserves_negative_values() {
-        let data = vec![group(-10.0), group(-5.0), group(-20.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Max),
-            Decimal::from(-5)
-        );
-    }
-
-    #[test]
-    fn reduce_min_preserves_positive_values_only() {
-        let data = vec![group(10.0), group(20.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Min),
-            Decimal::from(10)
-        );
-    }
-
-    #[test]
-    fn reduce_min_takes_smallest() {
-        let data = vec![group(10.0), group(5.0), group(20.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Min),
-            Decimal::from(5)
-        );
-    }
-
-    #[test]
-    fn reduce_mean_averages_groups() {
-        let data = vec![group(10.0), group(20.0), group(30.0)];
-        assert_eq!(
-            reduce_usage(&data, BillingMetricAggregateEnum::Mean),
-            Decimal::from(20)
-        );
-    }
-
-    #[test]
-    fn reduce_empty_returns_zero_for_all_types() {
-        for agg in [
-            BillingMetricAggregateEnum::Sum,
-            BillingMetricAggregateEnum::Count,
-            BillingMetricAggregateEnum::CountDistinct,
-            BillingMetricAggregateEnum::Max,
-            BillingMetricAggregateEnum::Latest,
-            BillingMetricAggregateEnum::Min,
-            BillingMetricAggregateEnum::Mean,
-        ] {
-            assert_eq!(reduce_usage(&[], agg), Decimal::ZERO, "failed for {agg:?}");
         }
     }
 
@@ -619,13 +512,11 @@ mod tests {
             entity: common_domain::ids::EntitlementEntityId::Feature(feature.id),
             name: None,
         };
-        let created_at = Utc::now();
         let metric_id = BillableMetricId::new();
         let limit = Some(Decimal::from(500));
 
         let ent = build_unavailable_metered_entitlement(
             feature.clone(),
-            created_at,
             origin,
             metric_id,
             limit,
@@ -638,7 +529,6 @@ mod tests {
         );
 
         assert_eq!(ent.feature.id, feature.id);
-        assert_eq!(ent.created_at, created_at);
         let EffectiveEntitlementValue::Metered {
             limit: l,
             warning_threshold_pct,

--- a/modules/meteroid/crates/meteroid-store/src/services/mod.rs
+++ b/modules/meteroid/crates/meteroid-store/src/services/mod.rs
@@ -105,6 +105,16 @@ impl ServicesEdge {
             .await
     }
 
+    pub async fn get_effective_entitlements_for_subscription(
+        &self,
+        subscription_id: SubscriptionId,
+        tenant_id: TenantId,
+    ) -> StoreResult<Vec<EffectiveEntitlement>> {
+        self.services
+            .get_effective_entitlements_for_subscription(subscription_id, tenant_id)
+            .await
+    }
+
     pub async fn update_subscription_slots(
         &self,
         tenant_id: common_domain::ids::TenantId,

--- a/modules/meteroid/proto/api/entitlements/v1/models.proto
+++ b/modules/meteroid/proto/api/entitlements/v1/models.proto
@@ -151,7 +151,6 @@ message EffectiveEntitlement {
     BooleanEntitlement boolean = 2;
     MeteredEntitlement metered = 3;
   }
-  string created_at = 4;
   // Highest-priority entity that contributed to the final value, with its human-readable name.
   ResolvedOrigin origin = 5;
 
@@ -179,7 +178,6 @@ message ResolvedEntitlement {
     BooleanResolved boolean = 2;
     MeteredResolved metered = 3;
   }
-  string created_at = 4;
   // Highest-priority entity that contributed to the final value, with its human-readable name.
   ResolvedOrigin origin = 5;
 

--- a/modules/meteroid/src/api/entitlements/mapping.rs
+++ b/modules/meteroid/src/api/entitlements/mapping.rs
@@ -314,7 +314,6 @@ pub fn effective_entitlement_to_proto(r: EffectiveEntitlement) -> proto::Effecti
             }),
         }),
         value: Some(value),
-        created_at: r.created_at.as_proto(),
         origin: Some(origin_to_proto(r.origin)),
     }
 }
@@ -351,7 +350,6 @@ pub fn resolved_entitlement_to_proto(r: ResolvedEntitlement) -> proto::ResolvedE
             }),
         }),
         value: Some(value),
-        created_at: r.created_at.as_proto(),
         origin: Some(origin_to_proto(r.origin)),
     }
 }

--- a/modules/meteroid/src/api/entitlements/service.rs
+++ b/modules/meteroid/src/api/entitlements/service.rs
@@ -384,7 +384,11 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(&mut conn, tenant_id, ResolveTarget::Product(product_id))
+            .resolve_entitlements_for_entity(
+                &mut conn,
+                tenant_id,
+                ResolveTarget::Product(product_id),
+            )
             .await
             .map_err(EntitlementApiError::from)?;
 
@@ -413,7 +417,7 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(&mut conn, tenant_id, ResolveTarget::AddOn(add_on_id))
+            .resolve_entitlements_for_entity(&mut conn, tenant_id, ResolveTarget::AddOn(add_on_id))
             .await
             .map_err(EntitlementApiError::from)?;
 
@@ -442,7 +446,7 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(
+            .resolve_entitlements_for_entity(
                 &mut conn,
                 tenant_id,
                 ResolveTarget::PlanVersion(plan_version_id),
@@ -475,7 +479,7 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(
+            .resolve_entitlements_for_entity(
                 &mut conn,
                 tenant_id,
                 ResolveTarget::Subscription(subscription_id),
@@ -508,7 +512,7 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(&mut conn, tenant_id, ResolveTarget::Quote(quote_id))
+            .resolve_entitlements_for_entity(&mut conn, tenant_id, ResolveTarget::Quote(quote_id))
             .await
             .map_err(EntitlementApiError::from)?;
 
@@ -547,7 +551,7 @@ impl EntitlementsService for EntitlementsComponents {
             .map_err(EntitlementApiError::from)?;
         let resolved = self
             .store
-            .resolve_for_entity(
+            .resolve_entitlements_for_entity(
                 &mut conn,
                 tenant_id,
                 ResolveTarget::Selection {

--- a/modules/meteroid/src/api_rest/addons/model.rs
+++ b/modules/meteroid/src/api_rest/addons/model.rs
@@ -1,4 +1,4 @@
-use crate::api_rest::entitlements::model::{Entitlement, EntitlementSpec};
+use crate::api_rest::entitlements::model::Entitlement;
 use crate::api_rest::model::{PaginatedRequest, PaginationResponse};
 use crate::api_rest::products::model::ProductFeeTypeEnum;
 use chrono::NaiveDateTime;
@@ -50,9 +50,6 @@ pub struct CreateAddOnRequest {
     #[serde(default)]
     pub self_serviceable: bool,
     pub max_instances_per_subscription: Option<i32>,
-    /// Inline entitlements to attach when creating this add-on.
-    #[serde(default)]
-    pub entitlements: Vec<EntitlementSpec>,
 }
 
 #[derive(Clone, Debug, Deserialize, Validate, ToSchema)]

--- a/modules/meteroid/src/api_rest/addons/router.rs
+++ b/modules/meteroid/src/api_rest/addons/router.rs
@@ -3,7 +3,7 @@ use super::AppState;
 use crate::api_rest::QueryParams;
 use crate::api_rest::addons::mapping;
 use crate::api_rest::addons::model::*;
-use crate::api_rest::entitlements::mapping::entitlement_spec_from_rest;
+
 use crate::api_rest::error::RestErrorResponse;
 use crate::api_rest::model::{PaginationExt, validate_order_by};
 use crate::errors::RestApiError;
@@ -126,12 +126,6 @@ pub(crate) async fn create_addon(
     State(app_state): State<AppState>,
     Valid(Json(payload)): Valid<Json<CreateAddOnRequest>>,
 ) -> Result<impl IntoResponse, RestApiError> {
-    let entitlements = payload
-        .entitlements
-        .into_iter()
-        .map(entitlement_spec_from_rest)
-        .collect();
-
     let addon = app_state
         .store
         .create_add_on(AddOnNew {
@@ -143,7 +137,7 @@ pub(crate) async fn create_addon(
             self_serviceable: payload.self_serviceable,
             max_instances_per_subscription: payload.max_instances_per_subscription,
             created_by: authorized_state.actor_id,
-            entitlements,
+            entitlements: vec![],
         })
         .await
         .map_err(|e| {

--- a/modules/meteroid/src/api_rest/entitlements/mapping.rs
+++ b/modules/meteroid/src/api_rest/entitlements/mapping.rs
@@ -3,13 +3,6 @@ use meteroid_store::domain::entitlements::{self as domain, ResolvedOrigin};
 
 use super::model::*;
 
-pub fn entitlement_spec_from_rest(spec: EntitlementSpec) -> domain::EntitlementSpec {
-    domain::EntitlementSpec {
-        feature_id: spec.feature_id,
-        value: value_from_rest(spec.value),
-    }
-}
-
 pub fn feature_to_rest(f: domain::Feature) -> Feature {
     Feature {
         id: f.id,
@@ -28,39 +21,22 @@ pub fn feature_to_rest(f: domain::Feature) -> Feature {
 
 pub fn value_to_rest(v: domain::EntitlementValue) -> EntitlementValue {
     match v {
-        domain::EntitlementValue::Boolean { enabled } => EntitlementValue::Boolean { enabled },
+        domain::EntitlementValue::Boolean { enabled } => {
+            EntitlementValue::Boolean(BooleanEntitlementValue { enabled })
+        }
         domain::EntitlementValue::Metered {
             limit,
             reset_period,
             overage_behavior,
             warning_threshold_pct,
             enabled,
-        } => EntitlementValue::Metered {
+        } => EntitlementValue::Metered(MeteredEntitlementValue {
             limit,
             reset_period: reset_period.into(),
             overage_behavior: overage_behavior.into(),
             warning_threshold_pct,
             enabled,
-        },
-    }
-}
-
-pub fn value_from_rest(v: EntitlementValue) -> domain::EntitlementValue {
-    match v {
-        EntitlementValue::Boolean { enabled } => domain::EntitlementValue::Boolean { enabled },
-        EntitlementValue::Metered {
-            limit,
-            reset_period,
-            overage_behavior,
-            warning_threshold_pct,
-            enabled,
-        } => domain::EntitlementValue::Metered {
-            limit,
-            reset_period: reset_period.into(),
-            overage_behavior: overage_behavior.into(),
-            warning_threshold_pct,
-            enabled,
-        },
+        }),
     }
 }
 
@@ -85,19 +61,27 @@ pub fn resolved_origin_to_rest(o: ResolvedOrigin) -> super::model::ResolvedOrigi
 /// Convert a domain `EntitlementEntityId` to the REST `EntitlementEntity` enum.
 pub fn entity_id_to_rest(entity: EntitlementEntityId) -> EntitlementEntity {
     match entity {
-        EntitlementEntityId::Feature(id) => EntitlementEntity::Feature { id },
-        EntitlementEntityId::Plan(id) => EntitlementEntity::Plan { id },
-        EntitlementEntityId::PlanVersion(id) => EntitlementEntity::PlanVersion { id },
-        EntitlementEntityId::AddOn(id) => EntitlementEntity::AddOn { id },
-        EntitlementEntityId::Subscription(id) => EntitlementEntity::Subscription { id },
-        EntitlementEntityId::Quote(id) => EntitlementEntity::Quote { id },
+        EntitlementEntityId::Feature(id) => {
+            EntitlementEntity::Feature(FeatureEntitlementEntity { id })
+        }
+        EntitlementEntityId::Plan(id) => EntitlementEntity::Plan(PlanEntitlementEntity { id }),
+        EntitlementEntityId::PlanVersion(id) => {
+            EntitlementEntity::PlanVersion(PlanVersionEntitlementEntity { id })
+        }
+        EntitlementEntityId::AddOn(id) => EntitlementEntity::AddOn(AddOnEntitlementEntity { id }),
+        EntitlementEntityId::Subscription(id) => {
+            EntitlementEntity::Subscription(SubscriptionEntitlementEntity { id })
+        }
+        EntitlementEntityId::Quote(id) => EntitlementEntity::Quote(QuoteEntitlementEntity { id }),
     }
 }
 
 pub fn resolved_entitlement_to_rest(r: domain::ResolvedEntitlement) -> ResolvedEntitlement {
     use domain::ResolvedEntitlementValue as DomVal;
     let value = match r.value {
-        DomVal::Boolean { enabled } => ResolvedEntitlementValue::Boolean { enabled },
+        DomVal::Boolean { enabled } => {
+            ResolvedEntitlementValue::Boolean(BooleanResolvedEntitlementValue { enabled })
+        }
         DomVal::Metered {
             metric_id,
             limit,
@@ -105,14 +89,14 @@ pub fn resolved_entitlement_to_rest(r: domain::ResolvedEntitlement) -> ResolvedE
             overage_behavior,
             warning_threshold_pct,
             enabled,
-        } => ResolvedEntitlementValue::Metered {
+        } => ResolvedEntitlementValue::Metered(MeteredResolvedEntitlementValue {
             metric_id,
             limit,
             reset_period: reset_period.into(),
             overage_behavior: overage_behavior.into(),
             warning_threshold_pct,
             enabled,
-        },
+        }),
     };
     ResolvedEntitlement {
         feature: FeatureRef {
@@ -124,7 +108,6 @@ pub fn resolved_entitlement_to_rest(r: domain::ResolvedEntitlement) -> ResolvedE
             }),
         },
         value,
-        created_at: r.created_at,
         origin: resolved_origin_to_rest(r.origin),
     }
 }
@@ -132,7 +115,7 @@ pub fn resolved_entitlement_to_rest(r: domain::ResolvedEntitlement) -> ResolvedE
 pub fn effective_entitlement_to_rest(r: domain::EffectiveEntitlement) -> EffectiveEntitlement {
     let value = match r.value {
         domain::EffectiveEntitlementValue::Boolean { enabled } => {
-            EffectiveEntitlementValue::Boolean { enabled }
+            EffectiveEntitlementValue::Boolean(BooleanEffectiveEntitlementValue { enabled })
         }
         domain::EffectiveEntitlementValue::Metered {
             metric_id,
@@ -142,7 +125,7 @@ pub fn effective_entitlement_to_rest(r: domain::EffectiveEntitlement) -> Effecti
             warning_threshold_pct,
             enabled,
             usage,
-        } => EffectiveEntitlementValue::Metered {
+        } => EffectiveEntitlementValue::Metered(MeteredEffectiveEntitlementValue {
             spec: MeteredEntitlementSpec {
                 metric_id,
                 limit,
@@ -156,7 +139,7 @@ pub fn effective_entitlement_to_rest(r: domain::EffectiveEntitlement) -> Effecti
                 remaining: usage.remaining,
                 reset_at: usage.reset_at,
             },
-        },
+        }),
     };
     EffectiveEntitlement {
         feature: FeatureRef {
@@ -168,7 +151,6 @@ pub fn effective_entitlement_to_rest(r: domain::EffectiveEntitlement) -> Effecti
             }),
         },
         value,
-        created_at: r.created_at,
         origin: resolved_origin_to_rest(r.origin),
     }
 }

--- a/modules/meteroid/src/api_rest/entitlements/model.rs
+++ b/modules/meteroid/src/api_rest/entitlements/model.rs
@@ -11,7 +11,7 @@ use utoipa::{IntoParams, ToSchema};
 use validator::Validate;
 
 fn default_reset_period() -> ResetPeriod {
-    ResetPeriod::Never
+    ResetPeriod::Never(NeverResetPeriod {})
 }
 
 fn default_metered_enabled_rest() -> bool {
@@ -30,15 +30,52 @@ pub enum FeatureStatus {
     Archived,
 }
 
+/// Deny access once usage reaches the limit. Meteroid does not enforce this — your integration must check and act.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct BlockOverageBehavior {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grace_period_pct: Option<u32>,
+}
+
+/// Keep serving usage past the limit; overage is billed or handled out-of-band.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct AllowOverageBehavior {}
+
 /// What happens past the limit.
-#[derive(o2o, Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-#[map_owned(meteroid_store::domain::entitlements::OverageBehavior)]
 pub enum OverageBehavior {
-    /// Deny access once usage reaches the limit. Meteroid does not enforce this — your integration must check and act.
-    Block { grace_period_pct: Option<u32> },
+    Block(BlockOverageBehavior),
     /// Keep serving usage past the limit; overage is billed or handled out-of-band.
-    Allow,
+    Allow(AllowOverageBehavior),
+}
+
+impl From<meteroid_store::domain::entitlements::OverageBehavior> for OverageBehavior {
+    fn from(v: meteroid_store::domain::entitlements::OverageBehavior) -> Self {
+        match v {
+            meteroid_store::domain::entitlements::OverageBehavior::Block { grace_period_pct } => {
+                OverageBehavior::Block(BlockOverageBehavior { grace_period_pct })
+            }
+            meteroid_store::domain::entitlements::OverageBehavior::Allow => {
+                OverageBehavior::Allow(AllowOverageBehavior {})
+            }
+        }
+    }
+}
+
+impl From<OverageBehavior> for meteroid_store::domain::entitlements::OverageBehavior {
+    fn from(v: OverageBehavior) -> Self {
+        match v {
+            OverageBehavior::Block(b) => {
+                meteroid_store::domain::entitlements::OverageBehavior::Block {
+                    grace_period_pct: b.grace_period_pct,
+                }
+            }
+            OverageBehavior::Allow(_) => {
+                meteroid_store::domain::entitlements::OverageBehavior::Allow
+            }
+        }
+    }
 }
 
 #[derive(o2o, Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, ToSchema)]
@@ -52,65 +89,166 @@ pub enum CalendarUnit {
     Year,
 }
 
-#[derive(o2o, Serialize, Deserialize, Debug, Clone, ToSchema)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-#[map_owned(meteroid_store::domain::entitlements::ResetPeriod)]
-pub enum ResetPeriod {
-    /// Resets at the start of each subscription billing period.
-    BillingCycle,
-    /// Buckets aligned to the calendar (e.g. every 1st of the month), shared across customers.
-    Calendar {
-        #[map(~.into())]
-        unit: CalendarUnit,
-        interval: u32,
-    },
-    /// Fixed-length buckets anchored on the subscription activation date. Resets at every boundary.
-    FixedWindow {
-        #[map(~.into())]
-        unit: CalendarUnit,
-        interval: u32,
-    },
-    /// Continuous rolling window — usage older than the window edge drops out, no fixed reset.
-    SlidingWindow {
-        #[map(~.into())]
-        unit: CalendarUnit,
-        interval: u32,
-    },
-    /// Usage accumulates for the life of the subscription — no reset.
-    Never,
+/// Resets each time your subscription renews — anchored to your billing cycle.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct BillingCycleResetPeriod {}
+
+/// Resets on calendar boundaries (e.g. the 1st of every month) — not tied to subscription start date.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct CalendarResetPeriod {
+    pub unit: CalendarUnit,
+    pub interval: u32,
 }
 
-#[derive(o2o, Serialize, Deserialize, Debug, Clone, ToSchema)]
+/// Resets at regular intervals — anchored to your subscription's exact activation time.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct FixedWindowResetPeriod {
+    pub unit: CalendarUnit,
+    pub interval: u32,
+}
+
+/// Always ends at now — e.g. 30 days means the last 30 days, old usage drops off automatically.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct SlidingWindowResetPeriod {
+    pub unit: CalendarUnit,
+    pub interval: u32,
+}
+
+/// Never resets — counts all usage since the subscription was activated.
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct NeverResetPeriod {}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-#[map_owned(meteroid_store::domain::entitlements::FeatureType)]
+pub enum ResetPeriod {
+    /// Resets each time your subscription renews — anchored to your billing cycle.
+    BillingCycle(BillingCycleResetPeriod),
+    /// Resets on calendar boundaries (e.g. the 1st of every month) — not tied to subscription start date.
+    Calendar(CalendarResetPeriod),
+    /// Resets at regular intervals — anchored to your subscription's exact activation time.
+    FixedWindow(FixedWindowResetPeriod),
+    /// Always ends at now — e.g. 30 days means the last 30 days, old usage drops off automatically.
+    SlidingWindow(SlidingWindowResetPeriod),
+    /// Never resets — counts all usage since the subscription was activated.
+    Never(NeverResetPeriod),
+}
+
+impl From<meteroid_store::domain::entitlements::ResetPeriod> for ResetPeriod {
+    fn from(v: meteroid_store::domain::entitlements::ResetPeriod) -> Self {
+        match v {
+            meteroid_store::domain::entitlements::ResetPeriod::BillingCycle => {
+                ResetPeriod::BillingCycle(BillingCycleResetPeriod {})
+            }
+            meteroid_store::domain::entitlements::ResetPeriod::Calendar { unit, interval } => {
+                ResetPeriod::Calendar(CalendarResetPeriod {
+                    unit: unit.into(),
+                    interval,
+                })
+            }
+            meteroid_store::domain::entitlements::ResetPeriod::FixedWindow { unit, interval } => {
+                ResetPeriod::FixedWindow(FixedWindowResetPeriod {
+                    unit: unit.into(),
+                    interval,
+                })
+            }
+            meteroid_store::domain::entitlements::ResetPeriod::SlidingWindow { unit, interval } => {
+                ResetPeriod::SlidingWindow(SlidingWindowResetPeriod {
+                    unit: unit.into(),
+                    interval,
+                })
+            }
+            meteroid_store::domain::entitlements::ResetPeriod::Never => {
+                ResetPeriod::Never(NeverResetPeriod {})
+            }
+        }
+    }
+}
+
+impl From<ResetPeriod> for meteroid_store::domain::entitlements::ResetPeriod {
+    fn from(v: ResetPeriod) -> Self {
+        match v {
+            ResetPeriod::BillingCycle(_) => {
+                meteroid_store::domain::entitlements::ResetPeriod::BillingCycle
+            }
+            ResetPeriod::Calendar(c) => {
+                meteroid_store::domain::entitlements::ResetPeriod::Calendar {
+                    unit: c.unit.into(),
+                    interval: c.interval,
+                }
+            }
+            ResetPeriod::FixedWindow(f) => {
+                meteroid_store::domain::entitlements::ResetPeriod::FixedWindow {
+                    unit: f.unit.into(),
+                    interval: f.interval,
+                }
+            }
+            ResetPeriod::SlidingWindow(s) => {
+                meteroid_store::domain::entitlements::ResetPeriod::SlidingWindow {
+                    unit: s.unit.into(),
+                    interval: s.interval,
+                }
+            }
+            ResetPeriod::Never(_) => meteroid_store::domain::entitlements::ResetPeriod::Never,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct BooleanFeatureType {}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct MeteredFeatureType {
+    #[serde(with = "string_serde")]
+    pub metric_id: BillableMetricId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum FeatureType {
-    Boolean,
-    Metered {
-        #[serde(with = "string_serde")]
-        metric_id: BillableMetricId,
-    },
+    Boolean(BooleanFeatureType),
+    Metered(MeteredFeatureType),
+}
+
+impl From<meteroid_store::domain::entitlements::FeatureType> for FeatureType {
+    fn from(v: meteroid_store::domain::entitlements::FeatureType) -> Self {
+        match v {
+            meteroid_store::domain::entitlements::FeatureType::Boolean => {
+                FeatureType::Boolean(BooleanFeatureType {})
+            }
+            meteroid_store::domain::entitlements::FeatureType::Metered { metric_id } => {
+                FeatureType::Metered(MeteredFeatureType { metric_id })
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct BooleanEntitlementValue {
+    pub enabled: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct MeteredEntitlementValue {
+    /// Cap on usage. Null means unlimited.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "decimal")]
+    pub limit: Option<Decimal>,
+    #[serde(default = "default_reset_period")]
+    pub reset_period: ResetPeriod,
+    pub overage_behavior: OverageBehavior,
+    /// Percentage of the Cap at which a warning triggers (0–100).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning_threshold_pct: Option<u32>,
+    /// Per-entitlement kill switch. `false` means disabled.
+    #[serde(default = "default_metered_enabled_rest")]
+    pub enabled: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum EntitlementValue {
-    Boolean {
-        enabled: bool,
-    },
-    Metered {
-        /// Cap on usage. Null means unlimited.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        limit: Option<Decimal>,
-        #[serde(default = "default_reset_period")]
-        reset_period: ResetPeriod,
-        overage_behavior: OverageBehavior,
-        /// Percentage of the Cap at which a warning triggers (0–100).
-        #[serde(skip_serializing_if = "Option::is_none")]
-        warning_threshold_pct: Option<u32>,
-        /// Per-entitlement kill switch. `false` means disabled.
-        #[serde(default = "default_metered_enabled_rest")]
-        enabled: bool,
-    },
+    Boolean(BooleanEntitlementValue),
+    Metered(MeteredEntitlementValue),
 }
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
@@ -118,6 +256,56 @@ pub struct MeteredEntitlementSpec {
     #[serde(serialize_with = "string_serde::serialize")]
     pub metric_id: BillableMetricId,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "decimal")]
+    pub limit: Option<Decimal>,
+    pub reset_period: ResetPeriod,
+    pub overage_behavior: OverageBehavior,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub warning_threshold_pct: Option<u32>,
+    pub enabled: bool,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct MeteredEntitlementUsage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "decimal")]
+    pub consumed: Option<Decimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "decimal")]
+    pub remaining: Option<Decimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reset_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct BooleanEffectiveEntitlementValue {
+    pub enabled: bool,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct MeteredEffectiveEntitlementValue {
+    pub spec: MeteredEntitlementSpec,
+    pub usage: MeteredEntitlementUsage,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EffectiveEntitlementValue {
+    Boolean(BooleanEffectiveEntitlementValue),
+    Metered(MeteredEffectiveEntitlementValue),
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct BooleanResolvedEntitlementValue {
+    pub enabled: bool,
+}
+
+#[derive(Serialize, Debug, Clone, ToSchema)]
+pub struct MeteredResolvedEntitlementValue {
+    #[serde(serialize_with = "string_serde::serialize")]
+    pub metric_id: BillableMetricId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>, format = "decimal")]
     pub limit: Option<Decimal>,
     pub reset_period: ResetPeriod,
     pub overage_behavior: OverageBehavior,
@@ -128,14 +316,56 @@ pub struct MeteredEntitlementSpec {
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
 #[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum EffectiveEntitlementValue {
-    Boolean {
-        enabled: bool,
-    },
-    Metered {
-        spec: MeteredEntitlementSpec,
-        usage: MeteredEntitlementUsage,
-    },
+pub enum ResolvedEntitlementValue {
+    Boolean(BooleanResolvedEntitlementValue),
+    Metered(MeteredResolvedEntitlementValue),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct FeatureEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: FeatureId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct PlanEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: PlanId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct PlanVersionEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: PlanVersionId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct AddOnEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: AddOnId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct SubscriptionEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: SubscriptionId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+pub struct QuoteEntitlementEntity {
+    #[serde(with = "common_domain::ids::string_serde")]
+    pub id: QuoteId,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
+#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EntitlementEntity {
+    Feature(FeatureEntitlementEntity),
+    Plan(PlanEntitlementEntity),
+    PlanVersion(PlanVersionEntitlementEntity),
+    AddOn(AddOnEntitlementEntity),
+    Subscription(SubscriptionEntitlementEntity),
+    Quote(QuoteEntitlementEntity),
 }
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
@@ -162,6 +392,7 @@ pub struct FeatureListResponse {
     pub pagination_meta: PaginationResponse,
 }
 
+/// A raw entitlement row attached to one entity (feature, plan version, add-on, or subscription).
 #[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
 pub struct Entitlement {
     #[serde(serialize_with = "string_serde::serialize")]
@@ -171,21 +402,6 @@ pub struct Entitlement {
     pub value: EntitlementValue,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
-}
-
-#[derive(Serialize, Debug, Clone, ToSchema)]
-pub struct EntitlementListResponse {
-    pub data: Vec<Entitlement>,
-}
-
-#[derive(Serialize, Debug, Clone, ToSchema)]
-pub struct MeteredEntitlementUsage {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub consumed: Option<Decimal>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remaining: Option<Decimal>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reset_at: Option<DateTime<Utc>>,
 }
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
@@ -204,12 +420,11 @@ pub struct FeatureRef {
     pub product: Option<ProductRef>,
 }
 
+/// Merged entitlement value for a feature for a specific customer, enriched with live usage data.
 #[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct EffectiveEntitlement {
     pub feature: FeatureRef,
     pub value: EffectiveEntitlementValue,
-    /// Earliest creation timestamp across the resolved entitlements that contributed.
-    pub created_at: DateTime<Utc>,
     /// Highest-priority entity that contributed to the final value, with its human-readable name.
     pub origin: ResolvedOrigin,
 }
@@ -227,66 +442,18 @@ pub struct ResolvedOrigin {
     pub name: Option<String>,
 }
 
+/// Merged entitlement value for a feature across the priority hierarchy, without usage data.
 #[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct ResolvedEntitlement {
     pub feature: FeatureRef,
     pub value: ResolvedEntitlementValue,
-    pub created_at: DateTime<Utc>,
     /// Highest-priority entity that contributed to the final value, with its human-readable name.
     pub origin: ResolvedOrigin,
 }
 
 #[derive(Serialize, Debug, Clone, ToSchema)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ResolvedEntitlementValue {
-    Boolean {
-        enabled: bool,
-    },
-    Metered {
-        #[serde(serialize_with = "string_serde::serialize")]
-        metric_id: BillableMetricId,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        limit: Option<Decimal>,
-        reset_period: ResetPeriod,
-        overage_behavior: OverageBehavior,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        warning_threshold_pct: Option<u32>,
-        enabled: bool,
-    },
-}
-
-#[derive(Serialize, Debug, Clone, ToSchema)]
 pub struct ResolvedEntitlementListResponse {
     pub data: Vec<ResolvedEntitlement>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, ToSchema)]
-#[serde(tag = "type", rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum EntitlementEntity {
-    Feature {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: FeatureId,
-    },
-    Plan {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: PlanId,
-    },
-    PlanVersion {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: PlanVersionId,
-    },
-    AddOn {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: AddOnId,
-    },
-    Subscription {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: SubscriptionId,
-    },
-    Quote {
-        #[serde(with = "common_domain::ids::string_serde")]
-        id: QuoteId,
-    },
 }
 
 #[derive(Deserialize, Debug, Clone, Validate, IntoParams)]
@@ -303,11 +470,4 @@ pub struct FeatureListRequest {
     pub product_id: Option<ProductId>,
     /// Search by feature name.
     pub search: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, Validate, ToSchema)]
-pub struct EntitlementSpec {
-    #[serde(with = "string_serde")]
-    pub feature_id: FeatureId,
-    pub value: EntitlementValue,
 }

--- a/modules/meteroid/src/api_rest/entitlements/router.rs
+++ b/modules/meteroid/src/api_rest/entitlements/router.rs
@@ -19,8 +19,8 @@ use meteroid_store::repositories::subscriptions::SubscriptionInterface;
 use crate::api_rest::QueryParams;
 use crate::api_rest::entitlements::mapping;
 use crate::api_rest::entitlements::model::{
-    EffectiveEntitlementListResponse, EntitlementListResponse, Feature, FeatureListRequest,
-    FeatureListResponse, ResolvedEntitlementListResponse,
+    EffectiveEntitlementListResponse, Feature, FeatureListRequest, FeatureListResponse,
+    ResolvedEntitlementListResponse,
 };
 use crate::api_rest::error::RestErrorResponse;
 use crate::api_rest::model::PaginationExt;
@@ -170,27 +170,32 @@ async fn verify_entity_ownership(
 
 // ── Entity entitlement list endpoints ─────────────────────────
 
-async fn list_entitlements_for(
+async fn resolve_entitlements_for(
     app_state: AppState,
     tenant_id: common_domain::ids::TenantId,
+    target: ResolveTarget,
     entity: EntitlementEntityId,
 ) -> Result<impl IntoResponse, RestApiError> {
     verify_entity_ownership(&app_state, tenant_id, &entity).await?;
 
-    let entitlements = app_state
+    let mut conn = app_state.store.get_conn().await.map_err(|e| {
+        log::error!("Error getting db connection: {e}");
+        RestApiError::StoreError
+    })?;
+    let resolved = app_state
         .store
-        .list_entitlements_by_entity(entity, tenant_id)
+        .resolve_entitlements_for_entity(&mut conn, tenant_id, target)
         .await
         .map_err(|e| {
-            log::error!("Error listing entitlements: {e}");
-            RestApiError::StoreError
+            log::error!("Error resolving entitlements: {e}");
+            RestApiError::from(e)
         })?;
 
-    let data = entitlements
+    let data = resolved
         .into_iter()
-        .map(mapping::entitlement_to_rest)
+        .map(mapping::resolved_entitlement_to_rest)
         .collect();
-    Ok(Json(EntitlementListResponse { data }))
+    Ok(Json(ResolvedEntitlementListResponse { data }))
 }
 
 /// List plan version entitlements
@@ -200,7 +205,7 @@ async fn list_entitlements_for(
     path = "/api/v1/plan-versions/{plan_version_id}/entitlements",
     params(("plan_version_id" = PlanVersionId, Path, description = "Plan version ID")),
     responses(
-        (status = 200, description = "Entitlements for this plan version", body = EntitlementListResponse),
+        (status = 200, description = "Resolved entitlements for this plan version", body = ResolvedEntitlementListResponse),
         (status = 401, description = "Unauthorized", body = RestErrorResponse),
         (status = 404, description = "Plan version not found", body = RestErrorResponse),
     ),
@@ -212,9 +217,10 @@ pub(crate) async fn list_plan_version_entitlements(
     State(app_state): State<AppState>,
     Path(plan_version_id): Path<PlanVersionId>,
 ) -> Result<impl IntoResponse, RestApiError> {
-    list_entitlements_for(
+    resolve_entitlements_for(
         app_state,
         authorized_state.tenant_id,
+        ResolveTarget::PlanVersion(plan_version_id),
         EntitlementEntityId::PlanVersion(plan_version_id),
     )
     .await
@@ -227,7 +233,7 @@ pub(crate) async fn list_plan_version_entitlements(
     path = "/api/v1/addons/{addon_id}/entitlements",
     params(("addon_id" = AddOnId, Path, description = "Add-on ID")),
     responses(
-        (status = 200, description = "Entitlements for this add-on", body = EntitlementListResponse),
+        (status = 200, description = "Resolved entitlements for this add-on", body = ResolvedEntitlementListResponse),
         (status = 401, description = "Unauthorized", body = RestErrorResponse),
         (status = 404, description = "Add-on not found", body = RestErrorResponse),
     ),
@@ -239,9 +245,10 @@ pub(crate) async fn list_add_on_entitlements(
     State(app_state): State<AppState>,
     Path(add_on_id): Path<AddOnId>,
 ) -> Result<impl IntoResponse, RestApiError> {
-    list_entitlements_for(
+    resolve_entitlements_for(
         app_state,
         authorized_state.tenant_id,
+        ResolveTarget::AddOn(add_on_id),
         EntitlementEntityId::AddOn(add_on_id),
     )
     .await
@@ -254,7 +261,7 @@ pub(crate) async fn list_add_on_entitlements(
     path = "/api/v1/subscriptions/{subscription_id}/entitlements",
     params(("subscription_id" = SubscriptionId, Path, description = "Subscription ID")),
     responses(
-        (status = 200, description = "Entitlements for this subscription", body = EntitlementListResponse),
+        (status = 200, description = "Effective entitlements for this subscription, with live usage", body = EffectiveEntitlementListResponse),
         (status = 401, description = "Unauthorized", body = RestErrorResponse),
         (status = 404, description = "Subscription not found", body = RestErrorResponse),
     ),
@@ -266,12 +273,20 @@ pub(crate) async fn list_subscription_entitlements(
     State(app_state): State<AppState>,
     Path(subscription_id): Path<SubscriptionId>,
 ) -> Result<impl IntoResponse, RestApiError> {
-    list_entitlements_for(
-        app_state,
-        authorized_state.tenant_id,
-        EntitlementEntityId::Subscription(subscription_id),
-    )
-    .await
+    let resolved = app_state
+        .services
+        .get_effective_entitlements_for_subscription(subscription_id, authorized_state.tenant_id)
+        .await
+        .map_err(|e| {
+            log::error!("Error resolving subscription entitlements: {e}");
+            RestApiError::from(e)
+        })?;
+
+    let data = resolved
+        .into_iter()
+        .map(mapping::effective_entitlement_to_rest)
+        .collect();
+    Ok(Json(EffectiveEntitlementListResponse { data }))
 }
 
 // ── Customer resolution ────────────────────────────────────────
@@ -279,7 +294,7 @@ pub(crate) async fn list_subscription_entitlements(
 /// List customer entitlements
 #[utoipa::path(
     get,
-    tags = ["Entitlements", "Customers"],
+    tags = ["Customers", "Entitlements"],
     path = "/api/v1/customers/{id_or_alias}/entitlements",
     params(
         ("id_or_alias" = String, Path, description = "Customer ID or alias"),
@@ -346,7 +361,7 @@ pub(crate) async fn list_product_entitlements(
     })?;
     let resolved = app_state
         .store
-        .resolve_for_entity(
+        .resolve_entitlements_for_entity(
             &mut conn,
             authorized_state.tenant_id,
             ResolveTarget::Product(product_id),

--- a/modules/meteroid/src/api_rest/plans/model.rs
+++ b/modules/meteroid/src/api_rest/plans/model.rs
@@ -1,4 +1,4 @@
-use crate::api_rest::entitlements::model::{Entitlement, EntitlementSpec};
+use crate::api_rest::entitlements::model::Entitlement;
 use crate::api_rest::model::PaginatedRequest;
 use crate::api_rest::model::PaginationResponse;
 use chrono::NaiveDateTime;
@@ -311,9 +311,6 @@ pub struct CreatePlanRequest {
     pub components: Vec<PriceComponentInput>,
     #[serde(default)]
     pub add_ons: Vec<PlanAddOnInput>,
-    /// Inline entitlements to attach to the plan version when creating this plan.
-    #[serde(default)]
-    pub entitlements: Vec<EntitlementSpec>,
 }
 
 fn validate_create_plan(req: &CreatePlanRequest) -> Result<(), validator::ValidationError> {

--- a/modules/meteroid/src/api_rest/plans/router.rs
+++ b/modules/meteroid/src/api_rest/plans/router.rs
@@ -1,7 +1,7 @@
 use super::AppState;
 
 use crate::api_rest::QueryParams;
-use crate::api_rest::entitlements::mapping::entitlement_spec_from_rest;
+
 use crate::api_rest::error::RestErrorResponse;
 use crate::api_rest::model::{PaginationExt, validate_order_by};
 use crate::api_rest::plans::mapping;
@@ -205,11 +205,7 @@ pub(crate) async fn create_plan(
             currency: Some(payload.currency),
             billing_cycles: billing.billing_cycles,
             trial,
-            entitlements: payload
-                .entitlements
-                .into_iter()
-                .map(entitlement_spec_from_rest)
-                .collect(),
+            entitlements: vec![],
         },
         price_components: components,
     };

--- a/modules/meteroid/src/api_rest/subscriptions/mapping.rs
+++ b/modules/meteroid/src/api_rest/subscriptions/mapping.rs
@@ -1,6 +1,6 @@
 use crate::api_rest::coupons::model::{CouponDiscount, FixedDiscount, PercentageDiscount};
 use crate::api_rest::currencies;
-use crate::api_rest::entitlements::mapping::{entitlement_spec_from_rest, entitlement_to_rest};
+use crate::api_rest::entitlements::mapping::entitlement_to_rest;
 use crate::api_rest::subscriptions::model::{
     AppliedCoupon, AppliedCouponDetailed, Coupon, CreateSubscriptionAddOn,
     CreateSubscriptionComponents, Subscription, SubscriptionAddOnCustomization,
@@ -184,11 +184,7 @@ pub fn rest_to_domain_create_request(
                 .map(|coupon_id| domain::CreateSubscriptionCoupon { coupon_id })
                 .collect(),
         }),
-        entitlements: sub
-            .entitlements
-            .into_iter()
-            .map(entitlement_spec_from_rest)
-            .collect(),
+        entitlements: vec![],
     };
 
     Ok(converted)

--- a/modules/meteroid/src/api_rest/subscriptions/model.rs
+++ b/modules/meteroid/src/api_rest/subscriptions/model.rs
@@ -1,5 +1,5 @@
 use crate::api_rest::currencies::model::Currency;
-use crate::api_rest::entitlements::model::{Entitlement, EntitlementSpec};
+use crate::api_rest::entitlements::model::Entitlement;
 use crate::api_rest::model::{BillingPeriodEnum, PaginatedRequest, PaginationResponse};
 use chrono::NaiveDate;
 use common_domain::ids::{
@@ -321,9 +321,6 @@ pub struct SubscriptionCreateRequest {
     /// The subscription will be set to the current billing period with correct cycle_index.
     #[schema(nullable = false)]
     pub skip_past_invoices: Option<bool>,
-    /// Inline entitlements to attach when creating this subscription.
-    #[serde(default)]
-    pub entitlements: Vec<EntitlementSpec>,
 }
 
 #[derive(o2o, Clone, ToSchema, Serialize, Deserialize, Debug)]

--- a/modules/meteroid/src/clients/usage.rs
+++ b/modules/meteroid/src/clients/usage.rs
@@ -186,6 +186,57 @@ impl UsageClient for MeteringUsageClient {
         Ok(UsageData { data, period })
     }
 
+    async fn fetch_total_usage(
+        &self,
+        tenant_id: &TenantId,
+        customer_id: &CustomerId,
+        metric: &BillableMetric,
+        period: UsagePeriod,
+    ) -> StoreResult<Decimal> {
+        if period.start >= period.end {
+            bail!(StoreError::InvalidArgument("invalid period".to_string()));
+        }
+
+        let request = QueryMeterRequest {
+            tenant_id: tenant_id.as_proto(),
+            meter_slug: metric.id.to_string(),
+            code: metric.code.clone(),
+            meter_aggregation_type: map_aggregation_type(&metric.aggregation_type),
+            customer_ids: vec![customer_id.to_string()],
+            from: Some(datetime_to_timestamp(period.start)),
+            to: Some(datetime_to_timestamp(period.end)),
+            group_by_properties: vec![],
+            window_size: QueryWindowSize::AggregateAll.into(),
+            timezone: None,
+            segmentation_filter: build_segmentation_filter(metric.segmentation_matrix.clone()),
+            value_property: metric.aggregation_key.clone(),
+        };
+
+        let mut client = self.usage_grpc_client.clone();
+        let response: QueryMeterResponse =
+            match tokio::time::timeout(GRPC_TIMEOUT, client.query_meter(request)).await {
+                Ok(result) => result
+                    .change_context(StoreError::MeteringServiceError)
+                    .attach("Failed to query meter (total)")?
+                    .into_inner(),
+                Err(_) => {
+                    log::error!(
+                        "query_meter (total) timed out after {} seconds",
+                        GRPC_TIMEOUT.as_secs()
+                    );
+                    return Err(error_stack::Report::new(StoreError::MeteringServiceError)
+                        .attach("query_meter (total) timed out"));
+                }
+            };
+
+        Ok(response
+            .usage
+            .into_iter()
+            .filter_map(|u| u.value.and_then(|v| v.try_into().ok()))
+            .next()
+            .unwrap_or(Decimal::ZERO))
+    }
+
     async fn fetch_windowed_usage(
         &self,
         tenant_id: &TenantId,

--- a/modules/web/web-app/features/entitlements/creation/EntitlementValueFields.tsx
+++ b/modules/web/web-app/features/entitlements/creation/EntitlementValueFields.tsx
@@ -61,15 +61,15 @@ function overageBehaviorHint(type: string | undefined): string {
 function resetPeriodHint(type: string | undefined): string {
   switch (type) {
     case 'never':
-      return 'Usage accumulates for the life of the subscription — no reset.'
+      return 'Never resets — counts all usage since the subscription was activated.'
     case 'billingCycle':
-      return 'Resets at the start of each subscription billing period.'
+      return 'Resets each time your subscription renews — anchored to your billing cycle.'
     case 'calendar':
-      return 'Buckets aligned to the calendar (e.g. every 1st of the month), shared across customers.'
+      return 'Resets on calendar boundaries (e.g. the 1st of every month) — not tied to subscription start date.'
     case 'fixedWindow':
-      return 'Fixed-length buckets anchored on the subscription activation date. Resets at every boundary.'
+      return 'Resets at regular intervals — anchored to your subscription\'s exact activation time.'
     case 'slidingWindow':
-      return 'Continuous rolling window — usage older than the window edge drops out, no fixed reset.'
+      return 'Always ends at now — e.g. 30 days means the last 30 days, old usage drops off automatically.'
     default:
       return ''
   }

--- a/modules/web/web-app/features/entitlements/pending/PendingEntitlementsPanel.tsx
+++ b/modules/web/web-app/features/entitlements/pending/PendingEntitlementsPanel.tsx
@@ -130,6 +130,7 @@ function buildMergedRows(
 
 type RowActionsProps = {
   row: MergedRow
+  entityLabel: string
   onOverride: (row: MergedRow) => void
   onPin: (row: MergedRow) => void
   onToggleDisable: (row: MergedRow) => void
@@ -138,6 +139,7 @@ type RowActionsProps = {
 
 const RowActions: FC<RowActionsProps> = ({
   row,
+  entityLabel,
   onOverride,
   onPin,
   onToggleDisable,
@@ -161,7 +163,7 @@ const RowActions: FC<RowActionsProps> = ({
               <Pencil size={12} />
             </button>
           </TooltipTrigger>
-          <TooltipContent>{entitlementTooltip('quote', 'override')}</TooltipContent>
+          <TooltipContent>{entitlementTooltip(entityLabel, 'override')}</TooltipContent>
         </Tooltip>
       )}
 
@@ -172,7 +174,7 @@ const RowActions: FC<RowActionsProps> = ({
               <PinOff size={12} />
             </button>
           </TooltipTrigger>
-          <TooltipContent>{entitlementTooltip('quote', 'unpin')}</TooltipContent>
+          <TooltipContent>{entitlementTooltip(entityLabel, 'unpin')}</TooltipContent>
         </Tooltip>
       ) : hasInherited ? (
         <Tooltip>
@@ -181,7 +183,7 @@ const RowActions: FC<RowActionsProps> = ({
               <Pin size={12} />
             </button>
           </TooltipTrigger>
-          <TooltipContent>{entitlementTooltip('quote', 'pin')}</TooltipContent>
+          <TooltipContent>{entitlementTooltip(entityLabel, 'pin')}</TooltipContent>
         </Tooltip>
       ) : null}
 
@@ -194,7 +196,7 @@ const RowActions: FC<RowActionsProps> = ({
                 : <CirclePower size={12} className="text-primary" />}
             </button>
           </TooltipTrigger>
-          <TooltipContent>{entitlementTooltip('quote', row.disabled ? 'enable' : 'disable')}</TooltipContent>
+          <TooltipContent>{entitlementTooltip(entityLabel, row.disabled ? 'enable' : 'disable')}</TooltipContent>
         </Tooltip>
       )}
     </div>
@@ -207,11 +209,12 @@ type Props = {
   selection: SelectionInput
   pending: PendingEntitlementSpec[]
   onChange: (next: PendingEntitlementSpec[]) => void
+  entityLabel: string
 }
 
 // ── Main panel ────────────────────────────────────────────────────────────────
 
-export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChange }) => {
+export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChange, entityLabel }) => {
   // 1. Fetch resolved entitlements for the in-flight selection (plan + add-ons) as the baseline
   const { entitlements: inherited, isLoading } = useResolvedEntitlementsForSelection(selection)
 
@@ -257,7 +260,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
     if (!row.inherited) return
     const spec = resolvedToPendingSpec(row.inherited)
     upsertPending(spec)
-    toast.success(`"${row.featureName}" pinned on this quote.`)
+    toast.success(`"${row.featureName}" pinned on this ${entityLabel}.`)
   }
 
   const handleToggleDisable = (row: MergedRow) => {
@@ -282,7 +285,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
 
   const requestPinAll = () => {
     if (unpinnedRows.length === 0) {
-      toast.info('All entitlements are already pinned on this quote.')
+      toast.info(`All entitlements are already pinned on this ${entityLabel}.`)
       return
     }
     setPinAllOpen(true)
@@ -301,7 +304,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
       ...newSpecs,
     ])
     setPinAllOpen(false)
-    toast.success(`${newSpecs.length} entitlement${newSpecs.length === 1 ? '' : 's'} pinned on this quote.`)
+    toast.success(`${newSpecs.length} entitlement${newSpecs.length === 1 ? '' : 's'} pinned on this ${entityLabel}.`)
   }
 
   // Build the initialSpec for the Override dialog from the current row state
@@ -337,7 +340,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
                   Add entitlement
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>Attach a new entitlement to this quote.</TooltipContent>
+              <TooltipContent>{`Attach a new entitlement to this ${entityLabel}.`}</TooltipContent>
             </Tooltip>
 
             <Tooltip>
@@ -352,8 +355,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
                 </Button>
               </TooltipTrigger>
               <TooltipContent className="max-w-56">
-                Save local copies of every upstream entitlement on this quote.
-                Already-pinned entries are skipped.
+                {`Save local copies of every upstream entitlement on this ${entityLabel}. Already-pinned entries are skipped.`}
               </TooltipContent>
             </Tooltip>
         </div>
@@ -421,6 +423,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
                           </span>
                           <RowActions
                             row={row}
+                            entityLabel={entityLabel}
                             onOverride={handleOverride}
                             onPin={handlePin}
                             onToggleDisable={handleToggleDisable}
@@ -457,7 +460,7 @@ export const PendingEntitlementsPanel: FC<Props> = ({ selection, pending, onChan
               <AlertDialogDescription>
                 {`This will save local copies of ${unpinnedRows.length} inherited ${
                   unpinnedRows.length === 1 ? 'entitlement' : 'entitlements'
-                } on this quote. Pinned values stay fixed even if the plan version changes.`}
+                } on this ${entityLabel}. Pinned values stay fixed even if the plan version changes.`}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>

--- a/modules/web/web-app/pages/tenants/quotes/CreateQuote.tsx
+++ b/modules/web/web-app/pages/tenants/quotes/CreateQuote.tsx
@@ -839,6 +839,7 @@ export const CreateQuote = () => {
                       }}
                       pending={pendingEntitlements}
                       onChange={setPendingEntitlements}
+                      entityLabel="quote"
                     />
                   </CardContent>
                 </Card>

--- a/modules/web/web-app/pages/tenants/subscription/create/StepPlanAndCustomer.tsx
+++ b/modules/web/web-app/pages/tenants/subscription/create/StepPlanAndCustomer.tsx
@@ -249,6 +249,7 @@ export const StepPlanAndCustomer = () => {
                   }}
                   pending={state.entitlements}
                   onChange={next => setState(prev => ({ ...prev, entitlements: next }))}
+                  entityLabel="subscription"
                 />
               </PageSection>
             )}

--- a/spec/api/v1/openapi.json
+++ b/spec/api/v1/openapi.json
@@ -412,11 +412,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Entitlements for this add-on",
+            "description": "Resolved entitlements for this add-on",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntitlementListResponse"
+                  "$ref": "#/components/schemas/ResolvedEntitlementListResponse"
                 }
               }
             }
@@ -2311,8 +2311,8 @@
     "/api/v1/customers/{id_or_alias}/entitlements": {
       "get": {
         "tags": [
-          "Entitlements",
-          "Customers"
+          "Customers",
+          "Entitlements"
         ],
         "summary": "List customer entitlements",
         "operationId": "get_effective_entitlements",
@@ -3500,11 +3500,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Entitlements for this plan version",
+            "description": "Resolved entitlements for this plan version",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntitlementListResponse"
+                  "$ref": "#/components/schemas/ResolvedEntitlementListResponse"
                 }
               }
             }
@@ -5483,11 +5483,11 @@
         ],
         "responses": {
           "200": {
-            "description": "Entitlements for this subscription",
+            "description": "Effective entitlements for this subscription, with live usage",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/EntitlementListResponse"
+                  "$ref": "#/components/schemas/EffectiveEntitlementListResponse"
                 }
               }
             }
@@ -5894,6 +5894,17 @@
           }
         }
       },
+      "AddOnEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/AddOnId"
+          }
+        }
+      },
       "AddOnEvent": {
         "allOf": [
           {
@@ -6045,6 +6056,10 @@
             ]
           }
         }
+      },
+      "AllowOverageBehavior": {
+        "type": "object",
+        "description": "Keep serving usage past the limit; overage is billed or handled out-of-band."
       },
       "AppliedCoupon": {
         "type": "object",
@@ -6449,6 +6464,10 @@
           }
         }
       },
+      "BillingCycleResetPeriod": {
+        "type": "object",
+        "description": "Resets each time your subscription renews — anchored to your billing cycle."
+      },
       "BillingMetricAggregateEnum": {
         "type": "string",
         "enum": [
@@ -6483,6 +6502,74 @@
           "ADVANCE",
           "ARREARS"
         ]
+      },
+      "BlockOverageBehavior": {
+        "type": "object",
+        "description": "Deny access once usage reaches the limit. Meteroid does not enforce this — your integration must check and act.",
+        "properties": {
+          "grace_period_pct": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
+          }
+        }
+      },
+      "BooleanEffectiveEntitlementValue": {
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "BooleanEntitlementValue": {
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "BooleanFeatureType": {
+        "type": "object"
+      },
+      "BooleanResolvedEntitlementValue": {
+        "type": "object",
+        "required": [
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "CalendarResetPeriod": {
+        "type": "object",
+        "description": "Resets on calendar boundaries (e.g. the 1st of every month) — not tied to subscription start date.",
+        "required": [
+          "unit",
+          "interval"
+        ],
+        "properties": {
+          "interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "unit": {
+            "$ref": "#/components/schemas/CalendarUnit"
+          }
+        }
       },
       "CalendarUnit": {
         "type": "string",
@@ -7060,13 +7147,6 @@
               "null"
             ]
           },
-          "entitlements": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EntitlementSpec"
-            },
-            "description": "Inline entitlements to attach when creating this add-on."
-          },
           "max_instances_per_subscription": {
             "type": [
               "integer",
@@ -7399,13 +7479,6 @@
               "string",
               "null"
             ]
-          },
-          "entitlements": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EntitlementSpec"
-            },
-            "description": "Inline entitlements to attach to the plan version when creating this plan."
           },
           "name": {
             "type": "string"
@@ -8363,18 +8436,13 @@
       },
       "EffectiveEntitlement": {
         "type": "object",
+        "description": "Merged entitlement value for a feature for a specific customer, enriched with live usage data.",
         "required": [
           "feature",
           "value",
-          "created_at",
           "origin"
         ],
         "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Earliest creation timestamp across the resolved entitlements that contributed."
-          },
           "feature": {
             "$ref": "#/components/schemas/FeatureRef"
           },
@@ -8404,49 +8472,23 @@
       "EffectiveEntitlementValue": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "enabled",
-              "type"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BOOLEAN"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BooleanEffectiveEntitlementValue"
           },
           {
-            "type": "object",
-            "required": [
-              "spec",
-              "usage",
-              "type"
-            ],
-            "properties": {
-              "spec": {
-                "$ref": "#/components/schemas/MeteredEntitlementSpec"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "METERED"
-                ]
-              },
-              "usage": {
-                "$ref": "#/components/schemas/MeteredEntitlementUsage"
-              }
-            }
+            "$ref": "#/components/schemas/MeteredEffectiveEntitlementValue"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "BOOLEAN": "#/components/schemas/BooleanEffectiveEntitlementValue",
+            "METERED": "#/components/schemas/MeteredEffectiveEntitlementValue"
+          }
+        }
       },
       "Entitlement": {
         "type": "object",
+        "description": "A raw entitlement row attached to one entity (feature, plan version, add-on, or subscription).",
         "required": [
           "id",
           "feature_id",
@@ -8477,114 +8519,35 @@
       "EntitlementEntity": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/FeatureId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "FEATURE"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/FeatureEntitlementEntity"
           },
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/PlanId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "PLAN"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/PlanEntitlementEntity"
           },
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/PlanVersionId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "PLAN_VERSION"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/PlanVersionEntitlementEntity"
           },
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/AddOnId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ADD_ON"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/AddOnEntitlementEntity"
           },
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/SubscriptionId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "SUBSCRIPTION"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/SubscriptionEntitlementEntity"
           },
           {
-            "type": "object",
-            "required": [
-              "id",
-              "type"
-            ],
-            "properties": {
-              "id": {
-                "$ref": "#/components/schemas/QuoteId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "QUOTE"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/QuoteEntitlementEntity"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "ADD_ON": "#/components/schemas/AddOnEntitlementEntity",
+            "FEATURE": "#/components/schemas/FeatureEntitlementEntity",
+            "PLAN": "#/components/schemas/PlanEntitlementEntity",
+            "PLAN_VERSION": "#/components/schemas/PlanVersionEntitlementEntity",
+            "QUOTE": "#/components/schemas/QuoteEntitlementEntity",
+            "SUBSCRIPTION": "#/components/schemas/SubscriptionEntitlementEntity"
+          }
+        }
       },
       "EntitlementId": {
         "type": "string",
@@ -8593,97 +8556,22 @@
           "ent_7n42DGM5Tflk9n8mt7Fhc7"
         ]
       },
-      "EntitlementListResponse": {
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Entitlement"
-            }
-          }
-        }
-      },
-      "EntitlementSpec": {
-        "type": "object",
-        "required": [
-          "feature_id",
-          "value"
-        ],
-        "properties": {
-          "feature_id": {
-            "$ref": "#/components/schemas/FeatureId"
-          },
-          "value": {
-            "$ref": "#/components/schemas/EntitlementValue"
-          }
-        }
-      },
       "EntitlementValue": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "enabled",
-              "type"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BOOLEAN"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BooleanEntitlementValue"
           },
           {
-            "type": "object",
-            "required": [
-              "overage_behavior",
-              "type"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "description": "Per-entitlement kill switch. `false` means disabled."
-              },
-              "limit": {
-                "type": [
-                  "string",
-                  "null"
-                ],
-                "description": "Cap on usage. Null means unlimited."
-              },
-              "overage_behavior": {
-                "$ref": "#/components/schemas/OverageBehavior"
-              },
-              "reset_period": {
-                "$ref": "#/components/schemas/ResetPeriod"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "METERED"
-                ]
-              },
-              "warning_threshold_pct": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "int32",
-                "description": "Percentage of the Cap at which a warning triggers (0–100).",
-                "minimum": 0
-              }
-            }
+            "$ref": "#/components/schemas/MeteredEntitlementValue"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "BOOLEAN": "#/components/schemas/BooleanEntitlementValue",
+            "METERED": "#/components/schemas/MeteredEntitlementValue"
+          }
+        }
       },
       "ErrorCode": {
         "type": "string",
@@ -8940,6 +8828,17 @@
           }
         }
       },
+      "FeatureEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/FeatureId"
+          }
+        }
+      },
       "FeatureId": {
         "type": "string",
         "format": "MeteroidId",
@@ -9002,38 +8901,19 @@
       "FeatureType": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BOOLEAN"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BooleanFeatureType"
           },
           {
-            "type": "object",
-            "required": [
-              "metric_id",
-              "type"
-            ],
-            "properties": {
-              "metric_id": {
-                "$ref": "#/components/schemas/BillableMetricId"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "METERED"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/MeteredFeatureType"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "BOOLEAN": "#/components/schemas/BooleanFeatureType",
+            "METERED": "#/components/schemas/MeteredFeatureType"
+          }
+        }
       },
       "Fee": {
         "oneOf": [
@@ -9080,6 +8960,24 @@
           },
           "currency": {
             "type": "string"
+          }
+        }
+      },
+      "FixedWindowResetPeriod": {
+        "type": "object",
+        "description": "Resets at regular intervals — anchored to your subscription's exact activation time.",
+        "required": [
+          "unit",
+          "interval"
+        ],
+        "properties": {
+          "interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "unit": {
+            "$ref": "#/components/schemas/CalendarUnit"
           }
         }
       },
@@ -9642,6 +9540,21 @@
           }
         }
       },
+      "MeteredEffectiveEntitlementValue": {
+        "type": "object",
+        "required": [
+          "spec",
+          "usage"
+        ],
+        "properties": {
+          "spec": {
+            "$ref": "#/components/schemas/MeteredEntitlementSpec"
+          },
+          "usage": {
+            "$ref": "#/components/schemas/MeteredEntitlementUsage"
+          }
+        }
+      },
       "MeteredEntitlementSpec": {
         "type": "object",
         "required": [
@@ -9658,7 +9571,8 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "format": "decimal"
           },
           "metric_id": {
             "$ref": "#/components/schemas/BillableMetricId"
@@ -9686,13 +9600,15 @@
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "format": "decimal"
           },
           "remaining": {
             "type": [
               "string",
               "null"
-            ]
+            ],
+            "format": "decimal"
           },
           "reset_at": {
             "type": [
@@ -9700,6 +9616,90 @@
               "null"
             ],
             "format": "date-time"
+          }
+        }
+      },
+      "MeteredEntitlementValue": {
+        "type": "object",
+        "required": [
+          "overage_behavior"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "description": "Per-entitlement kill switch. `false` means disabled."
+          },
+          "limit": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "decimal",
+            "description": "Cap on usage. Null means unlimited."
+          },
+          "overage_behavior": {
+            "$ref": "#/components/schemas/OverageBehavior"
+          },
+          "reset_period": {
+            "$ref": "#/components/schemas/ResetPeriod"
+          },
+          "warning_threshold_pct": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "description": "Percentage of the Cap at which a warning triggers (0–100).",
+            "minimum": 0
+          }
+        }
+      },
+      "MeteredFeatureType": {
+        "type": "object",
+        "required": [
+          "metric_id"
+        ],
+        "properties": {
+          "metric_id": {
+            "$ref": "#/components/schemas/BillableMetricId"
+          }
+        }
+      },
+      "MeteredResolvedEntitlementValue": {
+        "type": "object",
+        "required": [
+          "metric_id",
+          "reset_period",
+          "overage_behavior",
+          "enabled"
+        ],
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "decimal"
+          },
+          "metric_id": {
+            "$ref": "#/components/schemas/BillableMetricId"
+          },
+          "overage_behavior": {
+            "$ref": "#/components/schemas/OverageBehavior"
+          },
+          "reset_period": {
+            "$ref": "#/components/schemas/ResetPeriod"
+          },
+          "warning_threshold_pct": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32",
+            "minimum": 0
           }
         }
       },
@@ -10039,6 +10039,10 @@
           }
         }
       },
+      "NeverResetPeriod": {
+        "type": "object",
+        "description": "Never resets — counts all usage since the subscription was activated."
+      },
       "NewProductRef": {
         "type": "object",
         "required": [
@@ -10170,45 +10174,21 @@
       "OverageBehavior": {
         "oneOf": [
           {
-            "type": "object",
-            "description": "Deny access once usage reaches the limit. Meteroid does not enforce this — your integration must check and act.",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "grace_period_pct": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "int32",
-                "minimum": 0
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BLOCK"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BlockOverageBehavior"
           },
           {
-            "type": "object",
-            "description": "Keep serving usage past the limit; overage is billed or handled out-of-band.",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "ALLOW"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/AllowOverageBehavior",
+            "description": "Keep serving usage past the limit; overage is billed or handled out-of-band."
           }
         ],
-        "description": "What happens past the limit."
+        "description": "What happens past the limit.",
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "ALLOW": "#/components/schemas/AllowOverageBehavior",
+            "BLOCK": "#/components/schemas/BlockOverageBehavior"
+          }
+        }
       },
       "PackagePlanPricing": {
         "type": "object",
@@ -10556,6 +10536,17 @@
           }
         }
       },
+      "PlanEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/PlanId"
+          }
+        }
+      },
       "PlanEvent": {
         "allOf": [
           {
@@ -10696,6 +10687,17 @@
             "PER_UNIT": "#/components/schemas/PerUnitPlanPricing",
             "TIERED": "#/components/schemas/TieredPlanPricing",
             "VOLUME": "#/components/schemas/VolumePlanPricing"
+          }
+        }
+      },
+      "PlanVersionEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/PlanVersionId"
           }
         }
       },
@@ -11143,6 +11145,17 @@
           }
         }
       },
+      "QuoteEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/QuoteId"
+          }
+        }
+      },
       "QuoteEvent": {
         "allOf": [
           {
@@ -11333,125 +11346,46 @@
       "ResetPeriod": {
         "oneOf": [
           {
-            "type": "object",
-            "description": "Resets at the start of each subscription billing period.",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BILLING_CYCLE"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BillingCycleResetPeriod",
+            "description": "Resets each time your subscription renews — anchored to your billing cycle."
           },
           {
-            "type": "object",
-            "description": "Buckets aligned to the calendar (e.g. every 1st of the month), shared across customers.",
-            "required": [
-              "unit",
-              "interval",
-              "type"
-            ],
-            "properties": {
-              "interval": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "CALENDAR"
-                ]
-              },
-              "unit": {
-                "$ref": "#/components/schemas/CalendarUnit"
-              }
-            }
+            "$ref": "#/components/schemas/CalendarResetPeriod",
+            "description": "Resets on calendar boundaries (e.g. the 1st of every month) — not tied to subscription start date."
           },
           {
-            "type": "object",
-            "description": "Fixed-length buckets anchored on the subscription activation date. Resets at every boundary.",
-            "required": [
-              "unit",
-              "interval",
-              "type"
-            ],
-            "properties": {
-              "interval": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "FIXED_WINDOW"
-                ]
-              },
-              "unit": {
-                "$ref": "#/components/schemas/CalendarUnit"
-              }
-            }
+            "$ref": "#/components/schemas/FixedWindowResetPeriod",
+            "description": "Resets at regular intervals — anchored to your subscription's exact activation time."
           },
           {
-            "type": "object",
-            "description": "Continuous rolling window — usage older than the window edge drops out, no fixed reset.",
-            "required": [
-              "unit",
-              "interval",
-              "type"
-            ],
-            "properties": {
-              "interval": {
-                "type": "integer",
-                "format": "int32",
-                "minimum": 0
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "SLIDING_WINDOW"
-                ]
-              },
-              "unit": {
-                "$ref": "#/components/schemas/CalendarUnit"
-              }
-            }
+            "$ref": "#/components/schemas/SlidingWindowResetPeriod",
+            "description": "Always ends at now — e.g. 30 days means the last 30 days, old usage drops off automatically."
           },
           {
-            "type": "object",
-            "description": "Usage accumulates for the life of the subscription — no reset.",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "NEVER"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/NeverResetPeriod",
+            "description": "Never resets — counts all usage since the subscription was activated."
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "BILLING_CYCLE": "#/components/schemas/BillingCycleResetPeriod",
+            "CALENDAR": "#/components/schemas/CalendarResetPeriod",
+            "FIXED_WINDOW": "#/components/schemas/FixedWindowResetPeriod",
+            "NEVER": "#/components/schemas/NeverResetPeriod",
+            "SLIDING_WINDOW": "#/components/schemas/SlidingWindowResetPeriod"
+          }
+        }
       },
       "ResolvedEntitlement": {
         "type": "object",
+        "description": "Merged entitlement value for a feature across the priority hierarchy, without usage data.",
         "required": [
           "feature",
           "value",
-          "created_at",
           "origin"
         ],
         "properties": {
-          "created_at": {
-            "type": "string",
-            "format": "date-time"
-          },
           "feature": {
             "$ref": "#/components/schemas/FeatureRef"
           },
@@ -11481,68 +11415,19 @@
       "ResolvedEntitlementValue": {
         "oneOf": [
           {
-            "type": "object",
-            "required": [
-              "enabled",
-              "type"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "BOOLEAN"
-                ]
-              }
-            }
+            "$ref": "#/components/schemas/BooleanResolvedEntitlementValue"
           },
           {
-            "type": "object",
-            "required": [
-              "metric_id",
-              "reset_period",
-              "overage_behavior",
-              "enabled",
-              "type"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "limit": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "metric_id": {
-                "$ref": "#/components/schemas/BillableMetricId"
-              },
-              "overage_behavior": {
-                "$ref": "#/components/schemas/OverageBehavior"
-              },
-              "reset_period": {
-                "$ref": "#/components/schemas/ResetPeriod"
-              },
-              "type": {
-                "type": "string",
-                "enum": [
-                  "METERED"
-                ]
-              },
-              "warning_threshold_pct": {
-                "type": [
-                  "integer",
-                  "null"
-                ],
-                "format": "int32",
-                "minimum": 0
-              }
-            }
+            "$ref": "#/components/schemas/MeteredResolvedEntitlementValue"
           }
-        ]
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "BOOLEAN": "#/components/schemas/BooleanResolvedEntitlementValue",
+            "METERED": "#/components/schemas/MeteredResolvedEntitlementValue"
+          }
+        }
       },
       "ResolvedOrigin": {
         "type": "object",
@@ -11595,6 +11480,24 @@
           },
           "same_as_billing": {
             "type": "boolean"
+          }
+        }
+      },
+      "SlidingWindowResetPeriod": {
+        "type": "object",
+        "description": "Always ends at now — e.g. 30 days means the last 30 days, old usage drops off automatically.",
+        "required": [
+          "unit",
+          "interval"
+        ],
+        "properties": {
+          "interval": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0
+          },
+          "unit": {
+            "$ref": "#/components/schemas/CalendarUnit"
           }
         }
       },
@@ -12134,13 +12037,6 @@
               "2025-11-01"
             ]
           },
-          "entitlements": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/EntitlementSpec"
-            },
-            "description": "Inline entitlements to attach when creating this subscription."
-          },
           "invoice_memo": {
             "type": "string"
           },
@@ -12382,6 +12278,17 @@
             "format": "int32",
             "description": "Trial duration in days",
             "minimum": 0
+          }
+        }
+      },
+      "SubscriptionEntitlementEntity": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/SubscriptionId"
           }
         }
       },


### PR DESCRIPTION
## Description
 - Subscription entitlements now return effective (merged + live usage) instead of raw rows; plan version and add-on entitlements return resolved (merged, no usage)
  - activation_date fixed from NaiveDate to NaiveDateTime — preserves sub-day precision for fixed-window reset periods
  - PendingEntitlementsPanel hardcoded "quote" label replaced with entityLabel prop, making it reusable for subscriptions
  - OpenAPI spec regenerated

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
