### PR TITLE
feat: Revisit the organization invite flow

### DIFF
--- a/crates/common-domain/src/auth.rs
+++ b/crates/common-domain/src/auth.rs
@@ -1,5 +1,11 @@
 use serde::{Deserialize, Serialize};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OrgMemberRole {
+    Admin,
+    Member,
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct JwtClaims {
     pub sub: String,

--- a/crates/common-domain/src/ids/mod.rs
+++ b/crates/common-domain/src/ids/mod.rs
@@ -11,6 +11,7 @@ mod macros;
 pub use alias_or::AliasOr;
 
 id_type!(OrganizationId, "org_");
+id_type!(OrganizationInviteId, "orginv_");
 id_type!(TenantId, "ten_");
 id_type!(CustomerId, "cus_");
 id_type!(SubscriptionId, "sub_");

--- a/crates/common-grpc/src/middleware/server/auth/mod.rs
+++ b/crates/common-grpc/src/middleware/server/auth/mod.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 pub use admin_layer::AdminAuthLayer;
 pub use admin_layer::AdminAuthService;
 use common_config::auth::InternalAuthConfig;
+use common_domain::auth::OrgMemberRole;
 use common_domain::ids::{
     CheckoutSessionId, CustomerId, InvoiceId, OrganizationId, QuoteId, TenantId,
 };
@@ -19,6 +20,8 @@ pub trait RequestExt {
     fn actor(&self) -> Result<Uuid, Status>;
     fn tenant(&self) -> Result<TenantId, Status>;
     fn organization(&self) -> Result<OrganizationId, Status>;
+    fn actor_role(&self) -> Result<OrgMemberRole, Status>;
+    fn require_admin(&self) -> Result<(), Status>;
     fn portal_resource(&self) -> Result<AuthorizedAsPortalUser, Status>;
 }
 
@@ -33,6 +36,14 @@ impl<T> RequestExt for tonic::Request<T> {
 
     fn organization(&self) -> Result<OrganizationId, Status> {
         extract_organization(self.extensions().get::<AuthorizedState>())
+    }
+
+    fn actor_role(&self) -> Result<OrgMemberRole, Status> {
+        extract_actor_role(self.extensions().get::<AuthorizedState>())
+    }
+
+    fn require_admin(&self) -> Result<(), Status> {
+        require_admin_role(self.extensions().get::<AuthorizedState>())
     }
 
     fn portal_resource(&self) -> Result<AuthorizedAsPortalUser, Status> {
@@ -53,9 +64,43 @@ impl<T> RequestExt for http::Request<T> {
         extract_organization(self.extensions().get::<AuthorizedState>())
     }
 
+    fn actor_role(&self) -> Result<OrgMemberRole, Status> {
+        extract_actor_role(self.extensions().get::<AuthorizedState>())
+    }
+
+    fn require_admin(&self) -> Result<(), Status> {
+        require_admin_role(self.extensions().get::<AuthorizedState>())
+    }
+
     fn portal_resource(&self) -> Result<AuthorizedAsPortalUser, Status> {
         extract_portal(self.extensions().get::<AuthorizedState>())
     }
+}
+
+pub fn extract_actor_role(maybe_auth: Option<&AuthorizedState>) -> Result<OrgMemberRole, Status> {
+    let authorized = maybe_auth.ok_or(Status::unauthenticated(
+        "Missing authorized state in request extensions",
+    ))?;
+
+    match authorized {
+        AuthorizedState::Organization { role, .. } => Ok(*role),
+        AuthorizedState::Tenant(t) => t
+            .actor
+            .role()
+            .ok_or_else(|| Status::permission_denied("Role is not available in this context.")),
+        _ => Err(Status::permission_denied(
+            "Role is not available in this context.",
+        )),
+    }
+}
+
+pub fn require_admin_role(maybe_auth: Option<&AuthorizedState>) -> Result<(), Status> {
+    if extract_actor_role(maybe_auth)? != OrgMemberRole::Admin {
+        return Err(Status::permission_denied(
+            "Only organization admins can perform this action.",
+        ));
+    }
+    Ok(())
 }
 
 pub fn extract_actor(maybe_auth: Option<&AuthorizedState>) -> Result<Uuid, Status> {
@@ -64,7 +109,7 @@ pub fn extract_actor(maybe_auth: Option<&AuthorizedState>) -> Result<Uuid, Statu
     ))?;
 
     let res = match authorized {
-        AuthorizedState::Tenant(tenant) => tenant.actor_id,
+        AuthorizedState::Tenant(tenant) => tenant.actor.id(),
         AuthorizedState::Organization { actor_id, .. } => *actor_id,
         AuthorizedState::User { user_id } => *user_id,
         AuthorizedState::Shared { .. } => {
@@ -160,9 +205,31 @@ pub enum AuthenticatedState {
     },
 }
 
+#[derive(Clone, Copy)]
+pub enum TenantActor {
+    ApiKey(Uuid),
+    User { id: Uuid, role: OrgMemberRole },
+}
+
+impl TenantActor {
+    pub fn id(&self) -> Uuid {
+        match self {
+            TenantActor::ApiKey(id) => *id,
+            TenantActor::User { id, .. } => *id,
+        }
+    }
+
+    pub fn role(&self) -> Option<OrgMemberRole> {
+        match self {
+            TenantActor::ApiKey(_) => None,
+            TenantActor::User { role, .. } => Some(*role),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AuthorizedAsTenant {
-    pub actor_id: Uuid,
+    pub actor: TenantActor,
     pub tenant_id: TenantId,
     pub organization_id: OrganizationId,
     pub tenant_env: TenantEnv,
@@ -225,6 +292,7 @@ pub enum AuthorizedState {
     Organization {
         actor_id: Uuid,
         organization_id: OrganizationId,
+        role: OrgMemberRole,
     },
     User {
         user_id: Uuid,

--- a/modules/metering/src/auth.rs
+++ b/modules/metering/src/auth.rs
@@ -19,7 +19,7 @@ use common_grpc::middleware::common::filters::Filter;
 
 use common_domain::ids::{OrganizationId, TenantId};
 use common_grpc::middleware::server::auth::{
-    AuthenticatedState, AuthorizedAsTenant, AuthorizedState, TenantEnv,
+    AuthenticatedState, AuthorizedAsTenant, AuthorizedState, TenantActor, TenantEnv,
 };
 use meteroid_grpc::meteroid::internal::v1::ResolveApiKeyRequest;
 use meteroid_grpc::meteroid::internal::v1::internal_service_client::InternalServiceClient;
@@ -116,7 +116,7 @@ where
                 } => Ok(AuthorizedState::Tenant(AuthorizedAsTenant {
                     tenant_id,
                     organization_id,
-                    actor_id: id,
+                    actor: TenantActor::ApiKey(id),
                     tenant_env,
                 })),
                 _ => Err(Box::new(Status::permission_denied(

--- a/modules/meteroid/crates/diesel-models/src/enums.rs
+++ b/modules/meteroid/crates/diesel-models/src/enums.rs
@@ -145,12 +145,21 @@ pub enum MrrMovementType {
     Reactivation,
 }
 
-#[derive(diesel_derive_enum::DbEnum, Debug, Clone)]
+#[derive(diesel_derive_enum::DbEnum, Debug, Clone, Copy, PartialEq, Eq)]
 #[ExistingTypePath = "crate::schema::sql_types::OrganizationUserRole"]
 #[DbValueStyle = "SCREAMING_SNAKE_CASE"]
 pub enum OrganizationUserRole {
     Admin,
     Member,
+}
+
+impl std::fmt::Display for OrganizationUserRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrganizationUserRole::Admin => write!(f, "Owner"),
+            OrganizationUserRole::Member => write!(f, "Member"),
+        }
+    }
 }
 
 #[derive(diesel_derive_enum::DbEnum, Debug, Clone, Eq, PartialEq)]

--- a/modules/meteroid/crates/diesel-models/src/lib.rs
+++ b/modules/meteroid/crates/diesel-models/src/lib.rs
@@ -10,6 +10,7 @@ pub mod entitlements;
 pub mod enums;
 pub mod errors;
 pub mod invoices;
+pub mod organization_invites;
 pub mod organization_members;
 pub mod organizations;
 pub mod plan_component_prices;

--- a/modules/meteroid/crates/diesel-models/src/organization_invites.rs
+++ b/modules/meteroid/crates/diesel-models/src/organization_invites.rs
@@ -1,0 +1,34 @@
+use chrono::DateTime;
+use chrono::Utc;
+use common_domain::ids::{OrganizationId, OrganizationInviteId};
+use diesel::{Identifiable, Insertable, Queryable, Selectable};
+use uuid::Uuid;
+
+use crate::enums::OrganizationUserRole;
+
+#[derive(Debug, Queryable, Identifiable, Selectable)]
+#[diesel(table_name = crate::schema::organization_invite)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct OrganizationInviteRow {
+    pub id: OrganizationInviteId,
+    pub organization_id: OrganizationId,
+    pub invited_email: String,
+    pub invited_by: Uuid,
+    pub role: OrganizationUserRole,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub accepted_at: Option<DateTime<Utc>>,
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = crate::schema::organization_invite)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct OrganizationInviteRowNew {
+    pub id: OrganizationInviteId,
+    pub organization_id: OrganizationId,
+    pub invited_email: String,
+    pub invited_by: Uuid,
+    pub role: OrganizationUserRole,
+    pub expires_at: DateTime<Utc>,
+}

--- a/modules/meteroid/crates/diesel-models/src/organizations.rs
+++ b/modules/meteroid/crates/diesel-models/src/organizations.rs
@@ -13,7 +13,6 @@ pub struct OrganizationRow {
     pub slug: String,
     pub created_at: NaiveDateTime,
     pub archived_at: Option<NaiveDateTime>,
-    pub invite_link_hash: Option<String>,
     pub default_country: CountryCode,
     pub is_express: bool,
 }

--- a/modules/meteroid/crates/diesel-models/src/query/mod.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/mod.rs
@@ -21,6 +21,7 @@ pub mod historical_rates_from_usd;
 pub mod invoices;
 pub mod invoicing_entities;
 pub mod oauth_verifiers;
+pub mod organization_invites;
 pub mod organization_members;
 pub mod organizations;
 pub mod outbox_event;

--- a/modules/meteroid/crates/diesel-models/src/query/organization_invites.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/organization_invites.rs
@@ -1,0 +1,182 @@
+use chrono::{DateTime, Utc};
+use diesel::{
+    ExpressionMethods, JoinOnDsl, OptionalExtension, QueryDsl, SelectableHelper, debug_query,
+};
+use diesel_async::RunQueryDsl;
+use error_stack::ResultExt;
+use tap::TapFallible;
+
+use common_domain::ids::{OrganizationId, OrganizationInviteId};
+
+use crate::errors::IntoDbResult;
+use crate::organization_invites::{OrganizationInviteRow, OrganizationInviteRowNew};
+use crate::{DbResult, PgConn};
+
+impl OrganizationInviteRowNew {
+    pub async fn insert(&self, conn: &mut PgConn) -> DbResult<OrganizationInviteRow> {
+        use crate::schema::organization_invite::dsl::organization_invite;
+        let query = diesel::insert_into(organization_invite).values(self);
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .get_result(conn)
+            .await
+            .attach("Error inserting organization_invite")
+            .into_db_result()
+    }
+}
+
+impl OrganizationInviteRow {
+    pub async fn find_by_id(
+        conn: &mut PgConn,
+        id: OrganizationInviteId,
+    ) -> DbResult<OrganizationInviteRow> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let query = oi_dsl::organization_invite.filter(oi_dsl::id.eq(id));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .first(conn)
+            .await
+            .attach("Error finding organization_invite by id")
+            .into_db_result()
+    }
+
+    pub async fn find_pending_by_email_and_org(
+        conn: &mut PgConn,
+        org_id: OrganizationId,
+        email: &str,
+    ) -> DbResult<Option<OrganizationInviteRow>> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let now = Utc::now();
+        // emails are normalized to lowercase on insert, so plain eq() suffices
+        let query = oi_dsl::organization_invite
+            .filter(oi_dsl::organization_id.eq(org_id))
+            .filter(oi_dsl::invited_email.eq(email.to_lowercase()))
+            .filter(oi_dsl::accepted_at.is_null())
+            .filter(oi_dsl::revoked_at.is_null())
+            .filter(oi_dsl::expires_at.gt(now));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .first(conn)
+            .await
+            .optional()
+            .attach("Error finding pending invite by email")
+            .into_db_result()
+    }
+
+    pub async fn update_expires_at(
+        conn: &mut PgConn,
+        id: OrganizationInviteId,
+        new_expires_at: DateTime<Utc>,
+    ) -> DbResult<()> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let query = diesel::update(oi_dsl::organization_invite)
+            .filter(oi_dsl::id.eq(id))
+            .set(oi_dsl::expires_at.eq(new_expires_at));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .execute(conn)
+            .await
+            .tap_err(|e| log::error!("Error updating invite expires_at: {e:?}"))
+            .attach("Error updating invite expires_at")
+            .into_db_result()
+            .map(|_| ())
+    }
+
+    pub async fn set_accepted_at(
+        conn: &mut PgConn,
+        id: OrganizationInviteId,
+        accepted_at: DateTime<Utc>,
+    ) -> DbResult<()> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let query = diesel::update(oi_dsl::organization_invite)
+            .filter(oi_dsl::id.eq(id))
+            .set(oi_dsl::accepted_at.eq(accepted_at));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .execute(conn)
+            .await
+            .tap_err(|e| log::error!("Error setting invite accepted_at: {e:?}"))
+            .attach("Error setting invite accepted_at")
+            .into_db_result()
+            .map(|_| ())
+    }
+
+    pub async fn set_revoked_at(
+        conn: &mut PgConn,
+        id: OrganizationInviteId,
+        revoked_at: DateTime<Utc>,
+    ) -> DbResult<()> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let query = diesel::update(oi_dsl::organization_invite)
+            .filter(oi_dsl::id.eq(id))
+            .set(oi_dsl::revoked_at.eq(revoked_at));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .execute(conn)
+            .await
+            .tap_err(|e| log::error!("Error setting invite revoked_at: {e:?}"))
+            .attach("Error setting invite revoked_at")
+            .into_db_result()
+            .map(|_| ())
+    }
+
+    pub async fn find_with_inviter_email(
+        conn: &mut PgConn,
+        id: OrganizationInviteId,
+    ) -> DbResult<(OrganizationInviteRow, String)> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        use crate::schema::user::dsl as u_dsl;
+        let result: (OrganizationInviteRow, String) = oi_dsl::organization_invite
+            .inner_join(u_dsl::user.on(oi_dsl::invited_by.eq(u_dsl::id)))
+            .filter(oi_dsl::id.eq(id))
+            .select((OrganizationInviteRow::as_select(), u_dsl::email))
+            .first(conn)
+            .await
+            .attach("Error finding invite with inviter email")
+            .into_db_result()?;
+        Ok(result)
+    }
+
+    pub async fn revoke_expired_for_email_and_org(
+        conn: &mut PgConn,
+        org_id: OrganizationId,
+        email: &str,
+    ) -> DbResult<()> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        let now = Utc::now();
+        let query = diesel::update(oi_dsl::organization_invite)
+            .filter(oi_dsl::organization_id.eq(org_id))
+            .filter(oi_dsl::invited_email.eq(email.to_lowercase()))
+            .filter(oi_dsl::accepted_at.is_null())
+            .filter(oi_dsl::revoked_at.is_null())
+            .filter(oi_dsl::expires_at.le(now))
+            .set(oi_dsl::revoked_at.eq(now));
+        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
+        query
+            .execute(conn)
+            .await
+            .tap_err(|e| log::error!("Error revoking expired invites: {e:?}"))
+            .attach("Error revoking expired invites")
+            .into_db_result()
+            .map(|_| ())
+    }
+
+    pub async fn list_pending_with_inviter_email(
+        conn: &mut PgConn,
+        org_id: OrganizationId,
+    ) -> DbResult<Vec<(OrganizationInviteRow, String)>> {
+        use crate::schema::organization_invite::dsl as oi_dsl;
+        use crate::schema::user::dsl as u_dsl;
+        oi_dsl::organization_invite
+            .inner_join(u_dsl::user.on(oi_dsl::invited_by.eq(u_dsl::id)))
+            .filter(oi_dsl::organization_id.eq(org_id))
+            .filter(oi_dsl::accepted_at.is_null())
+            .filter(oi_dsl::revoked_at.is_null())
+            .order(oi_dsl::created_at.desc())
+            .select((OrganizationInviteRow::as_select(), u_dsl::email))
+            .get_results(conn)
+            .await
+            .attach("Error listing pending invites with inviter")
+            .into_db_result()
+    }
+}

--- a/modules/meteroid/crates/diesel-models/src/query/organizations.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/organizations.rs
@@ -41,24 +41,6 @@ impl OrganizationRow {
             .into_db_result()
     }
 
-    pub async fn find_by_invite_link(
-        conn: &mut PgConn,
-        invite_link_hash: String,
-    ) -> DbResult<OrganizationRow> {
-        use crate::schema::organization::dsl as o_dsl;
-        use diesel_async::RunQueryDsl;
-
-        let query = o_dsl::organization.filter(o_dsl::invite_link_hash.eq(invite_link_hash));
-
-        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
-
-        query
-            .first(conn)
-            .await
-            .attach("Error while finding organization by invite_link_hash")
-            .into_db_result()
-    }
-
     pub async fn get_by_id(conn: &mut PgConn, id: OrganizationId) -> DbResult<OrganizationRow> {
         use crate::schema::organization::dsl as o_dsl;
         use diesel_async::RunQueryDsl;
@@ -105,28 +87,6 @@ impl OrganizationRow {
             .first(conn)
             .await
             .attach("Error while finding organization by slug")
-            .into_db_result()
-    }
-
-    pub async fn update_invite_link(
-        conn: &mut PgConn,
-        param_id: OrganizationId,
-        new_invite_hash_link: &String,
-    ) -> DbResult<usize> {
-        use crate::schema::organization::dsl as o_dsl;
-        use diesel_async::RunQueryDsl;
-
-        let query = diesel::update(o_dsl::organization)
-            .filter(o_dsl::id.eq(param_id))
-            .set(o_dsl::invite_link_hash.eq(new_invite_hash_link));
-
-        log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));
-
-        query
-            .execute(conn)
-            .await
-            .tap_err(|e| log::error!("Error while updating organization: {e:?}"))
-            .attach("Error while updating organization")
             .into_db_result()
     }
 

--- a/modules/meteroid/crates/diesel-models/src/query/users.rs
+++ b/modules/meteroid/crates/diesel-models/src/query/users.rs
@@ -149,6 +149,7 @@ impl UserRow {
         let query = u_dsl::user
             .inner_join(om_dsl::organization_member.on(u_dsl::id.eq(om_dsl::user_id)))
             .filter(om_dsl::organization_id.eq(organization_id))
+            .order_by((om_dsl::role.asc(), u_dsl::email.asc()))
             .select(UserWithRoleRow::as_select());
 
         log::debug!("{}", debug_query::<diesel::pg::Pg, _>(&query));

--- a/modules/meteroid/crates/diesel-models/src/schema.rs
+++ b/modules/meteroid/crates/diesel-models/src/schema.rs
@@ -792,9 +792,25 @@ diesel::table! {
         slug -> Text,
         created_at -> Timestamp,
         archived_at -> Nullable<Timestamp>,
-        invite_link_hash -> Nullable<Text>,
         default_country -> Text,
         is_express -> Bool,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+    use super::sql_types::OrganizationUserRole;
+
+    organization_invite (id) {
+        id -> Uuid,
+        organization_id -> Uuid,
+        invited_email -> Text,
+        invited_by -> Uuid,
+        role -> OrganizationUserRole,
+        created_at -> Timestamptz,
+        expires_at -> Timestamptz,
+        accepted_at -> Nullable<Timestamptz>,
+        revoked_at -> Nullable<Timestamptz>,
     }
 }
 
@@ -1372,6 +1388,8 @@ diesel::joinable!(invoice -> plan_version (plan_version_id));
 diesel::joinable!(invoice -> tenant (tenant_id));
 diesel::joinable!(invoicing_entity -> bank_account (bank_account_id));
 diesel::joinable!(invoicing_entity -> tenant (tenant_id));
+diesel::joinable!(organization_invite -> organization (organization_id));
+diesel::joinable!(organization_invite -> user (invited_by));
 diesel::joinable!(organization_member -> organization (organization_id));
 diesel::joinable!(organization_member -> user (user_id));
 diesel::joinable!(payment_transaction -> checkout_session (checkout_session_id));
@@ -1469,6 +1487,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     invoicing_entity,
     oauth_verifier,
     organization,
+    organization_invite,
     organization_member,
     outbox_event,
     payment_transaction,

--- a/modules/meteroid/crates/meteroid-mailer/Cargo.toml
+++ b/modules/meteroid/crates/meteroid-mailer/Cargo.toml
@@ -14,7 +14,7 @@ secrecy = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 itertools = { workspace = true }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["std"] }
 sailfish = { workspace = true }
 log = { workspace = true }
 rusty-money = { workspace = true }

--- a/modules/meteroid/crates/meteroid-mailer/src/model.rs
+++ b/modules/meteroid/crates/meteroid-mailer/src/model.rs
@@ -168,6 +168,16 @@ pub struct QuoteReady {
     pub account: String,
 }
 
+#[derive(Clone)]
+pub struct OrgInvite {
+    pub org_name: String,
+    pub inviter_name: String,
+    pub role: String,
+    pub invite_url: String,
+    pub expires_in: String,
+    pub recipient: EmailRecipient,
+}
+
 impl TryInto<Mailbox> for EmailRecipient {
     type Error = Report<MailerServiceError>;
 

--- a/modules/meteroid/crates/meteroid-mailer/src/service.rs
+++ b/modules/meteroid/crates/meteroid-mailer/src/service.rs
@@ -1,11 +1,11 @@
 use crate::config::MailerConfig;
 use crate::errors::MailerServiceError;
 use crate::model::{
-    Email, EmailValidationLink, InvoicePaid, InvoiceReady, QuoteReady, ResetPasswordLink,
+    Email, EmailValidationLink, InvoicePaid, InvoiceReady, OrgInvite, QuoteReady, ResetPasswordLink,
 };
 use crate::template::{
-    EmailValidationLinkTemplate, InvoicePaidTemplate, InvoiceReadyTemplate, QuoteReadyTemplate,
-    ResetPasswordLinkTemplate,
+    EmailValidationLinkTemplate, InvoicePaidTemplate, InvoiceReadyTemplate, OrgInviteTemplate,
+    QuoteReadyTemplate, ResetPasswordLinkTemplate,
 };
 use async_trait::async_trait;
 use error_stack::Report;
@@ -41,6 +41,8 @@ pub trait MailerService: Send + Sync {
     async fn send_invoice_paid(&self, link: InvoicePaid) -> Result<(), Report<MailerServiceError>>;
 
     async fn send_quote_ready(&self, data: QuoteReady) -> Result<(), Report<MailerServiceError>>;
+
+    async fn send_org_invite(&self, data: OrgInvite) -> Result<(), Report<MailerServiceError>>;
 }
 
 pub struct LettreMailerService<T: AsyncTransport> {
@@ -173,6 +175,20 @@ where
             subject: title,
             body_html,
             attachments: vec![], // No PDF attachment for quote email, they access via portal
+        };
+        self.send(email).await
+    }
+
+    async fn send_org_invite(&self, data: OrgInvite) -> Result<(), Report<MailerServiceError>> {
+        let tpl = OrgInviteTemplate::from(data.clone()).tpl;
+        let body_html = tpl.render_once().map_err(|e| Report::new(e.into()))?;
+        let email = Email {
+            from: self.config.from.clone(),
+            reply_to: Some("No Reply <no-reply@meteroid.com>".into()),
+            to: vec![data.recipient],
+            subject: format!("You've been invited to join {} on Meteroid", data.org_name),
+            body_html,
+            attachments: vec![],
         };
         self.send(email).await
     }

--- a/modules/meteroid/crates/meteroid-mailer/src/template.rs
+++ b/modules/meteroid/crates/meteroid-mailer/src/template.rs
@@ -1,4 +1,6 @@
-use crate::model::{EmailValidationLink, InvoicePaid, InvoiceReady, QuoteReady, ResetPasswordLink};
+use crate::model::{
+    EmailValidationLink, InvoicePaid, InvoiceReady, OrgInvite, QuoteReady, ResetPasswordLink,
+};
 use sailfish::TemplateSimple;
 use secrecy::ExposeSecret;
 
@@ -220,6 +222,46 @@ impl From<QuoteReady> for QuoteReadyTemplate {
             tpl: LayoutTemplate {
                 lang: "en".to_string(),
                 title: format!("Quote {} from {}", content.quote_number, data.company_name),
+                header,
+                footer,
+                content,
+            },
+        }
+    }
+}
+
+#[derive(TemplateSimple)]
+#[template(path = "org_invite.stpl")]
+pub struct OrgInviteContent {
+    pub org_name: String,
+    pub inviter_name: String,
+    pub role: String,
+    pub invite_url: String,
+    pub expires_in: String,
+}
+
+pub struct OrgInviteTemplate {
+    pub tpl: LayoutTemplate<OrgInviteContent>,
+}
+
+impl From<OrgInvite> for OrgInviteTemplate {
+    fn from(data: OrgInvite) -> Self {
+        let header = HeaderTemplate {
+            company_name: data.org_name.clone(),
+            logo_url: Some(METEROID_WORDMARK_URL.to_string()),
+        };
+        let footer = FooterTemplate {};
+        let content = OrgInviteContent {
+            org_name: data.org_name.clone(),
+            inviter_name: data.inviter_name,
+            role: data.role,
+            invite_url: data.invite_url,
+            expires_in: data.expires_in,
+        };
+        OrgInviteTemplate {
+            tpl: LayoutTemplate {
+                lang: "en".to_string(),
+                title: format!("You've been invited to join {}", content.org_name),
                 header,
                 footer,
                 content,

--- a/modules/meteroid/crates/meteroid-mailer/templates/org_invite.stpl
+++ b/modules/meteroid/crates/meteroid-mailer/templates/org_invite.stpl
@@ -1,0 +1,15 @@
+<div class="content-section">
+  <h1>You've been invited to join <%= org_name %></h1>
+</div>
+
+<div class="content-section">
+  <p><%= inviter_name %> has invited you to join <strong><%= org_name %></strong> as <strong><%= role %></strong>.</p>
+
+  <div class="button-container">
+    <a href="<%= invite_url %>" class="button">ACCEPT INVITATION</a>
+  </div>
+
+  <p class="expiry">This invite expires in <%= expires_in %>.</p>
+
+  <p class="small">Or copy and paste this link: <a href="<%= invite_url %>" class="small"><%= invite_url %></a></p>
+</div>

--- a/modules/meteroid/crates/meteroid-middleware/src/server/auth/api_layer.rs
+++ b/modules/meteroid/crates/meteroid-middleware/src/server/auth/api_layer.rs
@@ -11,7 +11,7 @@ use common_grpc::middleware::common::auth::{
 };
 use common_grpc::middleware::common::filters::Filter;
 use common_grpc::middleware::server::AuthorizedState;
-use common_grpc::middleware::server::auth::{AuthenticatedState, AuthorizedAsTenant};
+use common_grpc::middleware::server::auth::{AuthenticatedState, AuthorizedAsTenant, TenantActor};
 use futures_util::TryFutureExt;
 use futures_util::future::BoxFuture;
 use http::StatusCode;
@@ -71,7 +71,7 @@ impl<S> Layer<S> for ApiAuthLayer {
 // services that don't require authentication
 const ANONYMOUS_SERVICES: [&str; 8] = [
     "/meteroid.api.instance.v1.InstanceService/GetInstance",
-    "/meteroid.api.instance.v1.InstanceService/GetOrganizationByInviteLink",
+    "/meteroid.api.instance.v1.InstanceService/GetInviteDetails",
     "/meteroid.api.instance.v1.InstanceService/GetCountries",
     "/meteroid.api.users.v1.UsersService/InitRegistration",
     "/meteroid.api.users.v1.UsersService/CompleteRegistration",
@@ -150,7 +150,7 @@ where
                 } => Ok(AuthorizedState::Tenant(AuthorizedAsTenant {
                     tenant_id,
                     organization_id,
-                    actor_id: id,
+                    actor: TenantActor::ApiKey(id),
                     tenant_env,
                 })),
                 AuthenticatedState::User { id } => {

--- a/modules/meteroid/crates/meteroid-middleware/src/server/auth/strategies/jwt_strategy.rs
+++ b/modules/meteroid/crates/meteroid-middleware/src/server/auth/strategies/jwt_strategy.rs
@@ -1,10 +1,12 @@
 use cached::proc_macro::cached;
-use common_domain::auth::{Audience, JwtClaims};
+use common_domain::auth::{Audience, JwtClaims, OrgMemberRole};
 use common_domain::ids::{OrganizationId, TenantId};
 use common_grpc::GrpcServiceMethod;
 use common_grpc::middleware::common::auth::{BEARER_AUTH_HEADER, INTERNAL_API_CONTEXT_HEADER};
 use common_grpc::middleware::server::AuthorizedState;
-use common_grpc::middleware::server::auth::{AuthenticatedState, AuthorizedAsTenant, TenantEnv};
+use common_grpc::middleware::server::auth::{
+    AuthenticatedState, AuthorizedAsTenant, TenantActor, TenantEnv,
+};
 use http::HeaderMap;
 use jsonwebtoken::DecodingKey;
 use meteroid_store::Store;
@@ -171,7 +173,13 @@ pub async fn authorize_user(
             AuthorizedState::Tenant(AuthorizedAsTenant {
                 tenant_id,
                 organization_id,
-                actor_id: user_id,
+                actor: TenantActor::User {
+                    id: user_id,
+                    role: match role {
+                        OrganizationUserRole::Admin => OrgMemberRole::Admin,
+                        OrganizationUserRole::Member => OrgMemberRole::Member,
+                    },
+                },
                 tenant_env,
             }),
         )
@@ -181,6 +189,10 @@ pub async fn authorize_user(
             AuthorizedState::Organization {
                 organization_id,
                 actor_id: user_id,
+                role: match role {
+                    OrganizationUserRole::Admin => OrgMemberRole::Admin,
+                    OrganizationUserRole::Member => OrgMemberRole::Member,
+                },
             },
         )
     };

--- a/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/enums.rs
@@ -183,7 +183,7 @@ pub enum MrrMovementType {
     Reactivation,
 }
 
-#[derive(o2o, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(o2o, Serialize, Deserialize, Debug, Clone, Copy, Eq, PartialEq)]
 #[map_owned(diesel_enums::OrganizationUserRole)]
 pub enum OrganizationUserRole {
     Admin,

--- a/modules/meteroid/crates/meteroid-store/src/domain/organizations.rs
+++ b/modules/meteroid/crates/meteroid-store/src/domain/organizations.rs
@@ -1,8 +1,10 @@
 use crate::domain::{InvoicingEntityNew, Tenant};
-use chrono::NaiveDateTime;
+use chrono::{DateTime, NaiveDateTime, Utc};
 use common_domain::country::CountryCode;
-use common_domain::ids::OrganizationId;
+use common_domain::ids::{OrganizationId, OrganizationInviteId};
 use common_utils::rng::UPPER_ALPHANUMERIC;
+use diesel_models::enums::OrganizationUserRole;
+use diesel_models::organization_invites::OrganizationInviteRow;
 use diesel_models::organizations::OrganizationRow;
 use nanoid::nanoid;
 use o2o::o2o;
@@ -46,4 +48,39 @@ pub struct InstanceFlags {
     pub google_oauth_client_id: Option<String>,
     pub hubspot_oauth_client_id: Option<String>,
     pub pennylane_oauth_client_id: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OrganizationInvite {
+    pub id: OrganizationInviteId,
+    pub organization_id: OrganizationId,
+    pub invited_email: String,
+    pub invited_by_email: String,
+    pub role: OrganizationUserRole,
+    pub created_at: DateTime<Utc>,
+    pub expires_at: DateTime<Utc>,
+    pub is_expired: bool,
+}
+
+impl OrganizationInvite {
+    pub fn from_row_and_inviter(row: OrganizationInviteRow, inviter_email: String) -> Self {
+        let is_expired = row.expires_at < Utc::now();
+        OrganizationInvite {
+            id: row.id,
+            organization_id: row.organization_id,
+            invited_email: row.invited_email,
+            invited_by_email: inviter_email,
+            role: row.role,
+            created_at: row.created_at,
+            expires_at: row.expires_at,
+            is_expired,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct InviteDetails {
+    pub organization_name: String,
+    pub role: OrganizationUserRole,
+    pub invited_email: String,
 }

--- a/modules/meteroid/crates/meteroid-store/src/repositories/organizations.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/organizations.rs
@@ -1,18 +1,21 @@
 use crate::StoreResult;
 use crate::domain::enums::TenantEnvironmentEnum;
+use crate::domain::organizations::{InviteDetails, OrganizationInvite};
 use crate::domain::{
     InstanceFlags, Organization, OrganizationNew, OrganizationWithTenants, TenantNew,
 };
 use crate::errors::StoreError;
 use crate::store::Store;
-use common_domain::ids::{BaseId, OrganizationId, TenantId};
+use chrono::Utc;
+use common_domain::ids::{BaseId, OrganizationId, OrganizationInviteId, TenantId};
 use common_eventbus::Event;
-use common_utils::rng::BASE62_ALPHABET;
 use diesel_async::scoped_futures::ScopedFutureExt;
 use diesel_models::enums::OrganizationUserRole;
+use diesel_models::organization_invites::{OrganizationInviteRow, OrganizationInviteRowNew};
 use diesel_models::organization_members::OrganizationMemberRow;
 use diesel_models::organizations::{OrganizationRow, OrganizationRowNew};
 use diesel_models::tenants::TenantRow;
+use diesel_models::users::UserRow;
 use error_stack::Report;
 use meteroid_oauth::model::OauthProvider;
 use tracing_log::log;
@@ -27,12 +30,43 @@ pub trait OrganizationsInterface {
     ) -> StoreResult<OrganizationWithTenants>;
 
     async fn get_instance(&self) -> StoreResult<InstanceFlags>;
-    async fn organization_get_or_create_invite_link(
-        &self,
-        organization_id: OrganizationId,
-    ) -> StoreResult<String>;
 
-    async fn accept_invite(&self, user_id: Uuid, invite_key: String) -> StoreResult<Organization>;
+    async fn invite_member(
+        &self,
+        org_id: OrganizationId,
+        actor_id: Uuid,
+        invited_email: String,
+        role: OrganizationUserRole,
+    ) -> StoreResult<OrganizationInvite>;
+
+    async fn resend_invite(
+        &self,
+        invite_id: OrganizationInviteId,
+        actor_id: Uuid,
+        org_id: OrganizationId,
+    ) -> StoreResult<()>;
+
+    async fn revoke_invite(
+        &self,
+        invite_id: OrganizationInviteId,
+        org_id: OrganizationId,
+    ) -> StoreResult<()>;
+
+    async fn list_pending_invites(
+        &self,
+        org_id: OrganizationId,
+    ) -> StoreResult<Vec<OrganizationInvite>>;
+
+    async fn get_invite_details(
+        &self,
+        invite_id: OrganizationInviteId,
+    ) -> StoreResult<InviteDetails>;
+
+    async fn accept_invite(
+        &self,
+        user_id: Uuid,
+        invite_id: OrganizationInviteId,
+    ) -> StoreResult<Organization>;
 
     async fn leave_organization(&self, actor: Uuid, org_id: OrganizationId) -> StoreResult<()>;
 
@@ -42,11 +76,6 @@ pub trait OrganizationsInterface {
         target_user_id: Uuid,
         org_id: OrganizationId,
     ) -> StoreResult<()>;
-
-    async fn get_organization_by_invite_link(
-        &self,
-        invite_key: String,
-    ) -> StoreResult<Organization>;
 
     async fn list_organizations_for_user(&self, user_id: Uuid) -> StoreResult<Vec<Organization>>;
     async fn get_organization_by_id(&self, id: OrganizationId) -> StoreResult<Organization>;
@@ -190,59 +219,313 @@ impl OrganizationsInterface for Store {
         })
     }
 
-    async fn organization_get_or_create_invite_link(
+    async fn invite_member(
         &self,
-        organization_id: OrganizationId,
-    ) -> StoreResult<String> {
+        org_id: OrganizationId,
+        actor_id: Uuid,
+        invited_email: String,
+        role: OrganizationUserRole,
+    ) -> StoreResult<OrganizationInvite> {
         let mut conn = self.get_conn().await?;
 
-        let org = OrganizationRow::get_by_id(&mut conn, organization_id)
+        let actor_user = UserRow::find_by_id(&mut conn, actor_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+        if actor_user.email.to_lowercase() == invited_email.to_lowercase() {
+            return Err(
+                StoreError::InvalidArgument("You cannot invite yourself".to_string()).into(),
+            );
+        }
+
+        let invited_email = invited_email.to_lowercase();
+
+        let already_member = match UserRow::find_by_email(&mut conn, invited_email.clone()).await {
+            Ok(Some(existing_user)) => {
+                match OrganizationMemberRow::find_by_user_and_org(
+                    &mut conn,
+                    existing_user.id,
+                    org_id,
+                )
+                .await
+                .map_err(Into::<Report<StoreError>>::into)
+                {
+                    Ok(_) => true,
+                    Err(e) if matches!(e.current_context(), StoreError::ValueNotFound(_)) => false,
+                    Err(e) => return Err(e),
+                }
+            }
+            Ok(None) => false,
+            Err(e) => return Err(e.into()),
+        };
+        if already_member {
+            return Err(StoreError::InvalidArgument("User is already a member".to_string()).into());
+        }
+
+        if OrganizationInviteRow::find_pending_by_email_and_org(&mut conn, org_id, &invited_email)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?
+            .is_some()
+        {
+            return Err(StoreError::InvalidArgument(
+                "An active invite already exists for this email".to_string(),
+            )
+            .into());
+        }
+
+        OrganizationInviteRow::revoke_expired_for_email_and_org(&mut conn, org_id, &invited_email)
             .await
             .map_err(Into::<Report<StoreError>>::into)?;
 
-        if let Some(hash) = org.invite_link_hash {
-            Ok(hash)
-        } else {
-            log::warn!("Organization invite link is not set - creating new one");
+        let ttl_days = self.settings.invite_ttl_days;
+        let expires_at = Utc::now() + chrono::Duration::days(ttl_days as i64);
 
-            let invite_hash = nanoid::nanoid!(32, &BASE62_ALPHABET);
+        let row_new = OrganizationInviteRowNew {
+            id: OrganizationInviteId::new(),
+            organization_id: org_id,
+            invited_email: invited_email.clone(),
+            invited_by: actor_id,
+            role,
+            expires_at,
+        };
 
-            let _ = OrganizationRow::update_invite_link(&mut conn, org.id, &invite_hash)
-                .await
-                .map_err(Into::<Report<StoreError>>::into)?;
+        let row = row_new.insert(&mut conn).await.map_err(|e| {
+            let store_err = Into::<Report<StoreError>>::into(e);
+            if matches!(
+                store_err.current_context(),
+                StoreError::DuplicateValue { .. }
+            ) {
+                Report::new(StoreError::InvalidArgument(
+                    "An active invite already exists for this email".to_string(),
+                ))
+            } else {
+                store_err
+            }
+        })?;
 
-            Ok(invite_hash)
-        }
+        let org = OrganizationRow::get_by_id(&mut conn, org_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        self.send_invite_email(
+            row.id,
+            &org.trade_name,
+            &actor_user.email,
+            &role,
+            invited_email,
+        )
+        .await;
+
+        Ok(OrganizationInvite::from_row_and_inviter(
+            row,
+            actor_user.email,
+        ))
     }
 
-    async fn accept_invite(&self, user_id: Uuid, invite_key: String) -> StoreResult<Organization> {
+    async fn resend_invite(
+        &self,
+        invite_id: OrganizationInviteId,
+        actor_id: Uuid,
+        org_id: OrganizationId,
+    ) -> StoreResult<()> {
+        let mut conn = self.get_conn().await?;
+
+        let invite = OrganizationInviteRow::find_by_id(&mut conn, invite_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        if invite.organization_id != org_id {
+            return Err(StoreError::Forbidden(
+                "Invite does not belong to this organization".to_string(),
+            )
+            .into());
+        }
+        if invite.accepted_at.is_some() {
+            return Err(StoreError::InvalidArgument("Invite already accepted".to_string()).into());
+        }
+        if invite.revoked_at.is_some() {
+            return Err(StoreError::InvalidArgument("Invite is revoked".to_string()).into());
+        }
+        if invite.expires_at < Utc::now() {
+            return Err(StoreError::InvalidArgument(
+                "Invite is expired. Revoke it and create a new one.".to_string(),
+            )
+            .into());
+        }
+
+        let ttl_days = self.settings.invite_ttl_days;
+        let new_expires_at = Utc::now() + chrono::Duration::days(ttl_days as i64);
+
+        OrganizationInviteRow::update_expires_at(&mut conn, invite_id, new_expires_at)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        let org = OrganizationRow::get_by_id(&mut conn, org_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+        let actor_user = UserRow::find_by_id(&mut conn, actor_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        self.send_invite_email(
+            invite.id,
+            &org.trade_name,
+            &actor_user.email,
+            &invite.role,
+            invite.invited_email,
+        )
+        .await;
+
+        Ok(())
+    }
+
+    async fn revoke_invite(
+        &self,
+        invite_id: OrganizationInviteId,
+        org_id: OrganizationId,
+    ) -> StoreResult<()> {
+        let mut conn = self.get_conn().await?;
+
+        let invite = OrganizationInviteRow::find_by_id(&mut conn, invite_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        if invite.organization_id != org_id {
+            return Err(StoreError::Forbidden(
+                "Invite does not belong to this organization".to_string(),
+            )
+            .into());
+        }
+        if invite.accepted_at.is_some() {
+            return Err(StoreError::InvalidArgument("Invite already accepted".to_string()).into());
+        }
+        if invite.revoked_at.is_some() {
+            return Err(StoreError::InvalidArgument("Invite already revoked".to_string()).into());
+        }
+
+        OrganizationInviteRow::set_revoked_at(&mut conn, invite_id, Utc::now())
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        Ok(())
+    }
+
+    async fn list_pending_invites(
+        &self,
+        org_id: OrganizationId,
+    ) -> StoreResult<Vec<OrganizationInvite>> {
+        let mut conn = self.get_conn().await?;
+
+        let rows = OrganizationInviteRow::list_pending_with_inviter_email(&mut conn, org_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(row, inviter_email)| {
+                OrganizationInvite::from_row_and_inviter(row, inviter_email)
+            })
+            .collect())
+    }
+
+    async fn get_invite_details(
+        &self,
+        invite_id: OrganizationInviteId,
+    ) -> StoreResult<InviteDetails> {
+        let mut conn = self.get_conn().await?;
+
+        let invite = OrganizationInviteRow::find_by_id(&mut conn, invite_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        if invite.revoked_at.is_some()
+            || invite.accepted_at.is_some()
+            || invite.expires_at < Utc::now()
+        {
+            return Err(
+                StoreError::InvalidArgument("Invalid or expired invite link".to_string()).into(),
+            );
+        }
+
+        let org = OrganizationRow::get_by_id(&mut conn, invite.organization_id)
+            .await
+            .map_err(Into::<Report<StoreError>>::into)?;
+
+        Ok(InviteDetails {
+            organization_name: org.trade_name,
+            role: invite.role,
+            invited_email: invite.invited_email,
+        })
+    }
+
+    async fn accept_invite(
+        &self,
+        user_id: Uuid,
+        invite_id: OrganizationInviteId,
+    ) -> StoreResult<Organization> {
         let mut conn = self.get_conn().await?;
 
         self.transaction_with(&mut conn, |conn| {
             async move {
-                let org = OrganizationRow::find_by_invite_link(conn, invite_key)
+                let invite = OrganizationInviteRow::find_by_id(conn, invite_id)
                     .await
                     .map_err(Into::<Report<StoreError>>::into)?;
 
-                let existing_member =
-                    OrganizationMemberRow::find_by_user_and_org(conn, user_id, org.id)
-                        .await
-                        .ok();
-
-                if existing_member.is_some() {
+                if invite.accepted_at.is_some() {
                     return Err(StoreError::InvalidArgument(
-                        "User is already a member of this organization".to_string(),
+                        "This invite has already been used".to_string(),
+                    )
+                    .into());
+                }
+                if invite.revoked_at.is_some() || invite.expires_at < Utc::now() {
+                    return Err(StoreError::InvalidArgument(
+                        "Invalid or expired invite link".to_string(),
                     )
                     .into());
                 }
 
+                let user = UserRow::find_by_id(conn, user_id)
+                    .await
+                    .map_err(Into::<Report<StoreError>>::into)?;
+
+                if invite.invited_email.to_lowercase() != user.email.to_lowercase() {
+                    return Err(StoreError::Forbidden(
+                        "This invite is not valid for your account".to_string(),
+                    )
+                    .into());
+                }
+
+                match OrganizationMemberRow::find_by_user_and_org(
+                    conn,
+                    user_id,
+                    invite.organization_id,
+                )
+                .await
+                .map_err(Into::<Report<StoreError>>::into)
+                {
+                    Ok(_) => {
+                        return Err(StoreError::InvalidArgument(
+                            "You are already a member of this organization".to_string(),
+                        )
+                        .into());
+                    }
+                    Err(e) if matches!(e.current_context(), StoreError::ValueNotFound(_)) => {}
+                    Err(e) => return Err(e),
+                }
+
                 let org_member = OrganizationMemberRow {
                     user_id,
-                    organization_id: org.id,
-                    role: OrganizationUserRole::Member,
+                    organization_id: invite.organization_id,
+                    role: invite.role,
                 };
-
                 OrganizationMemberRow::insert(&org_member, conn)
+                    .await
+                    .map_err(Into::<Report<StoreError>>::into)?;
+
+                OrganizationInviteRow::set_accepted_at(conn, invite_id, Utc::now())
+                    .await
+                    .map_err(Into::<Report<StoreError>>::into)?;
+
+                let org = OrganizationRow::get_by_id(conn, invite.organization_id)
                     .await
                     .map_err(Into::<Report<StoreError>>::into)?;
 
@@ -323,19 +606,6 @@ impl OrganizationsInterface for Store {
             .scope_boxed()
         })
         .await
-    }
-
-    async fn get_organization_by_invite_link(
-        &self,
-        invite_key: String,
-    ) -> StoreResult<Organization> {
-        let mut conn = self.get_conn().await?;
-
-        let org = OrganizationRow::find_by_invite_link(&mut conn, invite_key)
-            .await
-            .map_err(Into::<Report<StoreError>>::into)?;
-
-        Ok(org.into())
     }
 
     async fn list_organizations_for_user(&self, user_id: Uuid) -> StoreResult<Vec<Organization>> {
@@ -490,5 +760,39 @@ impl OrganizationsInterface for Store {
             organization: org_created.into(),
             tenants: vec![tenant_created],
         })
+    }
+}
+
+impl Store {
+    async fn send_invite_email(
+        &self,
+        invite_id: OrganizationInviteId,
+        org_name: &str,
+        inviter_email: &str,
+        role: &OrganizationUserRole,
+        recipient_email: String,
+    ) {
+        let ttl_days = self.settings.invite_ttl_days;
+        let invite_url = format!(
+            "{}/invite?token={}",
+            self.settings.public_url.trim_end_matches('/'),
+            invite_id
+        );
+        let _ = self
+            .mailer
+            .send_org_invite(meteroid_mailer::model::OrgInvite {
+                org_name: org_name.to_string(),
+                inviter_name: inviter_email.to_string(),
+                role: format!("{}", role),
+                invite_url,
+                expires_in: format!("{} days", ttl_days),
+                recipient: meteroid_mailer::model::EmailRecipient {
+                    email: recipient_email,
+                    first_name: None,
+                    last_name: None,
+                },
+            })
+            .await
+            .map_err(|e| log::error!("Failed to send invite email: {e:?}"));
     }
 }

--- a/modules/meteroid/crates/meteroid-store/src/repositories/users.rs
+++ b/modules/meteroid/crates/meteroid-store/src/repositories/users.rs
@@ -1,5 +1,4 @@
 use crate::domain::Organization;
-use crate::domain::enums::OrganizationUserRole;
 use crate::domain::oauth::{OauthConnection, OauthVerifierData};
 use crate::domain::users::{
     InitRegistrationResponse, LoginUserRequest, LoginUserResponse, Me, RegisterUserRequest,
@@ -14,9 +13,10 @@ use argon2::password_hash::rand_core::OsRng;
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
 use chrono::{DateTime, Utc};
 use common_domain::auth::{Audience, JwtClaims, JwtPayload};
-use common_domain::ids::{OrganizationId, TenantId};
+use common_domain::ids::{OrganizationId, OrganizationInviteId, TenantId};
 use common_eventbus::Event;
 use diesel_async::scoped_futures::ScopedFutureExt;
+use diesel_models::organization_invites::OrganizationInviteRow;
 use diesel_models::organization_members::OrganizationMemberRow;
 use diesel_models::organizations::OrganizationRow;
 use diesel_models::users::{UserRow, UserRowNew, UserRowPatch};
@@ -199,7 +199,7 @@ impl UserInterface for Store {
                     .map_err(Into::<Report<StoreError>>::into)
                     .map(Into::into)?;
 
-            let role = user.role.clone();
+            let role = user.role;
             (user.into(), Some(role))
         } else {
             let user: User = UserRow::find_by_id(&mut conn, auth_user_id)
@@ -641,27 +641,51 @@ async fn register_user_internal(
             // we don't initiate an organization yet. User will be prompted to onboard.
             create_user(&mut conn, &req).await?
         }
-        Some(ref invite_link) => {
+        Some(ref invite_key) => {
+            let invite_id =
+                <OrganizationInviteId as std::str::FromStr>::from_str(invite_key.expose_secret())
+                    .map_err(|_| {
+                    Report::new(StoreError::InvalidArgument(
+                        "Invalid invite key".to_string(),
+                    ))
+                })?;
+
             let cloned_req = req.clone();
             store
                 .transaction(|conn| {
                     async move {
-                        let org_id = OrganizationRow::find_by_invite_link(
-                            conn,
-                            invite_link.expose_secret().to_string(),
-                        )
-                        .await
-                        .map_err(Into::<Report<StoreError>>::into)?
-                        .id;
+                        let invite = OrganizationInviteRow::find_by_id(conn, invite_id)
+                            .await
+                            .map_err(Into::<Report<StoreError>>::into)?;
+
+                        if invite.accepted_at.is_some()
+                            || invite.revoked_at.is_some()
+                            || invite.expires_at < Utc::now()
+                        {
+                            return Err(StoreError::InvalidArgument(
+                                "Invalid or expired invite link".to_string(),
+                            )
+                            .into());
+                        }
+                        if invite.invited_email.to_lowercase() != cloned_req.email.to_lowercase() {
+                            return Err(StoreError::Forbidden(
+                                "This invite is not valid for your account".to_string(),
+                            )
+                            .into());
+                        }
 
                         let created = create_user(conn, &cloned_req).await?;
 
                         let om = OrganizationMemberRow {
                             user_id: created,
-                            organization_id: org_id,
-                            role: OrganizationUserRole::Member.into(),
+                            organization_id: invite.organization_id,
+                            role: invite.role,
                         };
                         om.insert(conn)
+                            .await
+                            .map_err(Into::<Report<StoreError>>::into)?;
+
+                        OrganizationInviteRow::set_accepted_at(conn, invite_id, Utc::now())
                             .await
                             .map_err(Into::<Report<StoreError>>::into)?;
 

--- a/modules/meteroid/crates/meteroid-store/src/store.rs
+++ b/modules/meteroid/crates/meteroid-store/src/store.rs
@@ -36,6 +36,7 @@ pub struct Settings {
     pub domains_whitelist: Vec<String>,
     pub billing_default_plan_id: Option<PlanId>,
     pub admin_organization: Option<OrganizationId>,
+    pub invite_ttl_days: u32,
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -68,6 +69,7 @@ pub struct StoreConfig {
     pub billing: Option<Arc<PLACEHOLDER>>,
     pub billing_default_plan_id: Option<PlanId>,
     pub usage_client: Arc<dyn UsageClient>,
+    pub invite_ttl_days: u32,
 }
 
 /**
@@ -157,6 +159,7 @@ impl Store {
                 domains_whitelist: config.domains_whitelist,
                 billing_default_plan_id: config.billing_default_plan_id,
                 admin_organization: config.admin_organization_id,
+                invite_ttl_days: config.invite_ttl_days,
             },
             internal: StoreInternal {},
             mailer: config.mailer,

--- a/modules/meteroid/migrations/diesel/2026-06-09-000001_organization_invite/down.sql
+++ b/modules/meteroid/migrations/diesel/2026-06-09-000001_organization_invite/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE organization ADD COLUMN IF NOT EXISTS invite_link_hash TEXT UNIQUE;
+
+DROP TABLE IF EXISTS organization_invite;

--- a/modules/meteroid/migrations/diesel/2026-06-09-000001_organization_invite/up.sql
+++ b/modules/meteroid/migrations/diesel/2026-06-09-000001_organization_invite/up.sql
@@ -1,0 +1,17 @@
+CREATE TABLE organization_invite (
+    id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  UUID NOT NULL REFERENCES organization(id),
+    invited_email    TEXT NOT NULL,
+    invited_by       UUID NOT NULL REFERENCES "user"(id),
+    role             "OrganizationUserRole" NOT NULL DEFAULT 'MEMBER'::"OrganizationUserRole",
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    expires_at       TIMESTAMPTZ NOT NULL,
+    accepted_at      TIMESTAMPTZ,
+    revoked_at       TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX org_invite_pending_email_idx
+    ON organization_invite (organization_id, invited_email)
+    WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+ALTER TABLE organization DROP COLUMN IF EXISTS invite_link_hash;

--- a/modules/meteroid/proto/api/instance/v1/instance.proto
+++ b/modules/meteroid/proto/api/instance/v1/instance.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package meteroid.api.instance.v1;
 
+import "api/users/v1/models.proto";
+
 message GetInstanceRequest {}
 message GetInstanceResponse {
   bool multi_organization_enabled = 1;
@@ -13,18 +15,13 @@ message GetInstanceResponse {
   bool svix_enabled = 9;
 }
 
-message GetInviteRequest {}
-
-message GetInviteResponse {
-  string invite_hash = 1;
+message GetInviteDetailsRequest {
+  string invite_id = 1;
 }
-
-message GetOrganizationByInviteLinkRequest {
-  string invite_key = 1;
-}
-
-message GetOrganizationByInviteLinkResponse {
+message GetInviteDetailsResponse {
   string organization_name = 1;
+  meteroid.api.users.v1.OrganizationUserRole role = 2;
+  string invited_email = 3;
 }
 
 message GetCountriesRequest {}
@@ -67,8 +64,7 @@ message GetSubdivisionsResponse {
 
 service InstanceService {
   rpc GetInstance(GetInstanceRequest) returns (GetInstanceResponse) {}
-  rpc GetInvite(GetInviteRequest) returns (GetInviteResponse) {}
-  rpc GetOrganizationByInviteLink(GetOrganizationByInviteLinkRequest) returns (GetOrganizationByInviteLinkResponse) {}
+  rpc GetInviteDetails(GetInviteDetailsRequest) returns (GetInviteDetailsResponse) {}
   rpc GetCountries(GetCountriesRequest) returns (GetCountriesResponse) {}
   rpc GetCurrencies(GetCurrenciesRequest) returns (GetCurrenciesResponse) {}
   rpc GetSubdivisions(GetSubdivisionsRequest) returns (GetSubdivisionsResponse) {}

--- a/modules/meteroid/proto/api/users/v1/users.proto
+++ b/modules/meteroid/proto/api/users/v1/users.proto
@@ -88,7 +88,40 @@ message ResetPasswordRequest {
 message ResetPasswordResponse {}
 
 message AcceptInviteRequest {
-  string invite_key = 1;
+  string invite_id = 1;
+}
+
+message InviteMemberRequest {
+  string email = 1;
+  OrganizationUserRole role = 2;
+}
+message InviteMemberResponse {
+  string invite_id = 1;
+}
+
+message ResendInviteRequest {
+  string invite_id = 1;
+}
+message ResendInviteResponse {}
+
+message RevokeInviteRequest {
+  string invite_id = 1;
+}
+message RevokeInviteResponse {}
+
+message OrganizationInvite {
+  string id = 1;
+  string invited_email = 2;
+  OrganizationUserRole role = 3;
+  string invited_by_email = 4;
+  string created_at = 5;
+  string expires_at = 6;
+  bool is_expired = 7;
+}
+
+message ListPendingInvitesRequest {}
+message ListPendingInvitesResponse {
+  repeated OrganizationInvite invites = 1;
 }
 
 message AcceptInviteResponse {
@@ -118,6 +151,11 @@ service UsersService {
   rpc ResetPassword(ResetPasswordRequest) returns (ResetPasswordResponse) {}
 
   rpc AcceptInvite(AcceptInviteRequest) returns (AcceptInviteResponse) {}
+
+  rpc InviteMember(InviteMemberRequest) returns (InviteMemberResponse) {}
+  rpc ResendInvite(ResendInviteRequest) returns (ResendInviteResponse) {}
+  rpc RevokeInvite(RevokeInviteRequest) returns (RevokeInviteResponse) {}
+  rpc ListPendingInvites(ListPendingInvitesRequest) returns (ListPendingInvitesResponse) {}
 
   rpc LeaveOrganization(LeaveOrganizationRequest) returns (LeaveOrganizationResponse) {}
   rpc RemoveMember(RemoveMemberRequest) returns (RemoveMemberResponse) {}

--- a/modules/meteroid/src/api/instance/service.rs
+++ b/modules/meteroid/src/api/instance/service.rs
@@ -1,15 +1,14 @@
 use tonic::{Request, Response, Status};
 
 use common_domain::country::CountryCode;
-use common_grpc::middleware::server::auth::RequestExt;
+use common_domain::ids::OrganizationInviteId;
 use meteroid_grpc::meteroid::api::instance::v1::get_countries_response::Country as GrpcCountry;
 use meteroid_grpc::meteroid::api::instance::v1::get_currencies_response::Currency as GrpcCurrency;
 use meteroid_grpc::meteroid::api::instance::v1::get_subdivisions_response::Subdivision as GrpcSubdivision;
 use meteroid_grpc::meteroid::api::instance::v1::instance_service_server::InstanceService;
 use meteroid_grpc::meteroid::api::instance::v1::{
     GetCountriesRequest, GetCountriesResponse, GetCurrenciesRequest, GetCurrenciesResponse,
-    GetInstanceRequest, GetInstanceResponse, GetInviteRequest, GetInviteResponse,
-    GetOrganizationByInviteLinkRequest, GetOrganizationByInviteLinkResponse,
+    GetInstanceRequest, GetInstanceResponse, GetInviteDetailsRequest, GetInviteDetailsResponse,
     GetSubdivisionsRequest, GetSubdivisionsResponse,
 };
 use meteroid_store::constants::{COUNTRIES, CURRENCIES};
@@ -42,35 +41,25 @@ impl InstanceService for InstanceServiceComponents {
         }))
     }
 
-    async fn get_invite(
+    async fn get_invite_details(
         &self,
-        request: Request<GetInviteRequest>,
-    ) -> Result<Response<GetInviteResponse>, Status> {
-        let organization_id = request.organization()?;
-
-        let invite_hash = self
-            .store
-            .organization_get_or_create_invite_link(organization_id)
-            .await
-            .map_err(Into::<InstanceApiError>::into)?;
-
-        Ok(Response::new(GetInviteResponse { invite_hash }))
-    }
-
-    async fn get_organization_by_invite_link(
-        &self,
-        request: Request<GetOrganizationByInviteLinkRequest>,
-    ) -> Result<Response<GetOrganizationByInviteLinkResponse>, Status> {
+        request: Request<GetInviteDetailsRequest>,
+    ) -> Result<Response<GetInviteDetailsResponse>, Status> {
         let req = request.into_inner();
 
-        let organization = self
+        let invite_id = OrganizationInviteId::from_proto(&req.invite_id)
+            .map_err(|_| Status::invalid_argument("Invalid invite_id"))?;
+
+        let details = self
             .store
-            .get_organization_by_invite_link(req.invite_key)
+            .get_invite_details(invite_id)
             .await
             .map_err(Into::<InstanceApiError>::into)?;
 
-        Ok(Response::new(GetOrganizationByInviteLinkResponse {
-            organization_name: organization.trade_name,
+        Ok(Response::new(GetInviteDetailsResponse {
+            organization_name: details.organization_name,
+            role: crate::api::users::mapping::role::domain_to_server(details.role.into()).into(),
+            invited_email: details.invited_email,
         }))
     }
 

--- a/modules/meteroid/src/api/users/mapping.rs
+++ b/modules/meteroid/src/api/users/mapping.rs
@@ -8,6 +8,13 @@ pub mod role {
             OrganizationUserRole::Member => server::OrganizationUserRole::Member,
         }
     }
+
+    pub fn server_to_domain(role: server::OrganizationUserRole) -> OrganizationUserRole {
+        match role {
+            server::OrganizationUserRole::Admin => OrganizationUserRole::Admin,
+            server::OrganizationUserRole::Member => OrganizationUserRole::Member,
+        }
+    }
 }
 
 pub mod user {

--- a/modules/meteroid/src/api/users/service.rs
+++ b/modules/meteroid/src/api/users/service.rs
@@ -4,9 +4,12 @@ use meteroid_grpc::meteroid::api::users::v1::{
     AcceptInviteRequest, AcceptInviteResponse, CompleteRegistrationRequest,
     CompleteRegistrationResponse, GetUserByIdRequest, GetUserByIdResponse, InitRegistrationRequest,
     InitRegistrationResponse, InitResetPasswordRequest, InitResetPasswordResponse,
-    LeaveOrganizationRequest, LeaveOrganizationResponse, ListUsersRequest, ListUsersResponse,
+    InviteMemberRequest, InviteMemberResponse, LeaveOrganizationRequest, LeaveOrganizationResponse,
+    ListPendingInvitesRequest, ListPendingInvitesResponse, ListUsersRequest, ListUsersResponse,
     LoginRequest, LoginResponse, MeRequest, MeResponse, OnboardMeRequest, OnboardMeResponse,
-    RemoveMemberRequest, RemoveMemberResponse, ResetPasswordRequest, ResetPasswordResponse,
+    OrganizationInvite as GrpcOrganizationInvite, OrganizationUserRole as GrpcOrganizationUserRole,
+    RemoveMemberRequest, RemoveMemberResponse, ResendInviteRequest, ResendInviteResponse,
+    ResetPasswordRequest, ResetPasswordResponse, RevokeInviteRequest, RevokeInviteResponse,
     users_service_server::UsersService,
 };
 use meteroid_store::domain::users::{LoginUserRequest, RegisterUserRequest, UpdateUser};
@@ -16,8 +19,10 @@ use secrecy::{ExposeSecret, SecretString};
 use tonic::{Request, Response, Status};
 use validator::{ValidateEmail, ValidateLength};
 
+use crate::api::shared::conversions::ProtoConv;
 use crate::api::users::error::UserApiError;
 use crate::parse_uuid;
+use common_domain::ids::OrganizationInviteId;
 
 use super::{UsersServiceComponents, mapping};
 
@@ -251,9 +256,11 @@ impl UsersService for UsersServiceComponents {
         let actor = request.actor()?;
         let req = request.into_inner();
 
+        let invite_id = OrganizationInviteId::from_proto(&req.invite_id)?;
+
         let organization = self
             .store
-            .accept_invite(actor, req.invite_key)
+            .accept_invite(actor, invite_id)
             .await
             .map_err(Into::<UserApiError>::into)?;
 
@@ -261,6 +268,102 @@ impl UsersService for UsersServiceComponents {
             organization: Some(
                 super::super::organizations::mapping::organization::domain_to_proto(organization),
             ),
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn invite_member(
+        &self,
+        request: Request<InviteMemberRequest>,
+    ) -> Result<Response<InviteMemberResponse>, Status> {
+        let actor = request.actor()?;
+        let org_id = request.organization()?;
+        request.require_admin()?;
+        let req = request.into_inner();
+
+        let role = GrpcOrganizationUserRole::try_from(req.role)
+            .map_err(|_| Status::invalid_argument("Invalid role"))?;
+        let role = mapping::role::server_to_domain(role);
+
+        let invite = self
+            .store
+            .invite_member(org_id, actor, req.email, role.into())
+            .await
+            .map_err(Into::<UserApiError>::into)?;
+
+        Ok(Response::new(InviteMemberResponse {
+            invite_id: invite.id.to_string(),
+        }))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn resend_invite(
+        &self,
+        request: Request<ResendInviteRequest>,
+    ) -> Result<Response<ResendInviteResponse>, Status> {
+        let actor = request.actor()?;
+        let org_id = request.organization()?;
+        request.require_admin()?;
+        let req = request.into_inner();
+
+        let invite_id = OrganizationInviteId::from_proto(&req.invite_id)?;
+
+        self.store
+            .resend_invite(invite_id, actor, org_id)
+            .await
+            .map_err(Into::<UserApiError>::into)?;
+
+        Ok(Response::new(ResendInviteResponse {}))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn revoke_invite(
+        &self,
+        request: Request<RevokeInviteRequest>,
+    ) -> Result<Response<RevokeInviteResponse>, Status> {
+        let org_id = request.organization()?;
+        request.require_admin()?;
+        let req = request.into_inner();
+
+        let invite_id = OrganizationInviteId::from_proto(&req.invite_id)?;
+
+        self.store
+            .revoke_invite(invite_id, org_id)
+            .await
+            .map_err(Into::<UserApiError>::into)?;
+
+        Ok(Response::new(RevokeInviteResponse {}))
+    }
+
+    #[tracing::instrument(skip_all)]
+    async fn list_pending_invites(
+        &self,
+        request: Request<ListPendingInvitesRequest>,
+    ) -> Result<Response<ListPendingInvitesResponse>, Status> {
+        let org_id = request.organization()?;
+        request.require_admin()?;
+
+        let invites = self
+            .store
+            .list_pending_invites(org_id)
+            .await
+            .map_err(Into::<UserApiError>::into)?;
+
+        let grpc_invites = invites
+            .into_iter()
+            .map(|inv| GrpcOrganizationInvite {
+                id: inv.id.as_proto(),
+                invited_email: inv.invited_email,
+                role: mapping::role::domain_to_server(inv.role.into()).into(),
+                invited_by_email: inv.invited_by_email,
+                created_at: inv.created_at.as_proto(),
+                expires_at: inv.expires_at.as_proto(),
+                is_expired: inv.is_expired,
+            })
+            .collect();
+
+        Ok(Response::new(ListPendingInvitesResponse {
+            invites: grpc_invites,
         }))
     }
 

--- a/modules/meteroid/src/api_rest/addons/router.rs
+++ b/modules/meteroid/src/api_rest/addons/router.rs
@@ -136,7 +136,7 @@ pub(crate) async fn create_addon(
             description: payload.description,
             self_serviceable: payload.self_serviceable,
             max_instances_per_subscription: payload.max_instances_per_subscription,
-            created_by: authorized_state.actor_id,
+            created_by: authorized_state.actor.id(),
             entitlements: vec![],
         })
         .await
@@ -186,7 +186,7 @@ pub(crate) async fn update_addon(
                 max_instances_per_subscription: payload.max_instances_per_subscription,
             },
             price_entry,
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
         )
         .await
         .map_err(|e| {

--- a/modules/meteroid/src/api_rest/auth.rs
+++ b/modules/meteroid/src/api_rest/auth.rs
@@ -12,7 +12,9 @@ use tracing::{error, log};
 
 use crate::api_rest::error::{ErrorCode, RestErrorResponse};
 use common_domain::ids::{OrganizationId, TenantId};
-use common_grpc::middleware::server::auth::{AuthenticatedState, AuthorizedAsTenant, TenantEnv};
+use common_grpc::middleware::server::auth::{
+    AuthenticatedState, AuthorizedAsTenant, TenantActor, TenantEnv,
+};
 use meteroid_store::Store;
 use meteroid_store::errors::StoreError;
 use meteroid_store::repositories::api_tokens::ApiTokensInterface;
@@ -49,7 +51,7 @@ pub async fn auth_middleware(
         let state = AuthorizedAsTenant {
             tenant_id,
             organization_id,
-            actor_id: id,
+            actor: TenantActor::ApiKey(id),
             tenant_env,
         };
         req.extensions_mut().insert(state);

--- a/modules/meteroid/src/api_rest/checkoutsessions/router.rs
+++ b/modules/meteroid/src/api_rest/checkoutsessions/router.rs
@@ -82,7 +82,7 @@ pub async fn create_checkout_session(
         tenant_id,
         customer_id,
         plan_version_id: request.plan_version_id,
-        created_by: authorized_state.actor_id,
+        created_by: authorized_state.actor.id(),
         billing_start_date: request.billing_start_date,
         billing_day_anchor: request.billing_day_anchor.map(|a| a as i16),
         net_terms: request.net_terms,

--- a/modules/meteroid/src/api_rest/customers/router.rs
+++ b/modules/meteroid/src/api_rest/customers/router.rs
@@ -144,7 +144,7 @@ pub(crate) async fn create_customer(
     let created = app_state
         .store
         .insert_customer(
-            create_req_to_domain(authorized_state.actor_id, payload)?,
+            create_req_to_domain(authorized_state.actor.id(), payload)?,
             authorized_state.tenant_id,
         )
         .await
@@ -195,7 +195,7 @@ pub(crate) async fn update_customer(
     app_state
         .store
         .update_customer(
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
             authorized_state.tenant_id,
             update_req_to_domain(id_or_alias, payload),
         )
@@ -250,7 +250,7 @@ pub(crate) async fn patch_customer(
     let updated = app_state
         .store
         .patch_customer(
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
             authorized_state.tenant_id,
             patch_req_to_domain(customer.id, payload),
         )
@@ -295,7 +295,7 @@ pub(crate) async fn archive_customer(
     app_state
         .store
         .archive_customer(
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
             authorized_state.tenant_id,
             id_or_alias,
         )

--- a/modules/meteroid/src/api_rest/metrics/router.rs
+++ b/modules/meteroid/src/api_rest/metrics/router.rs
@@ -145,7 +145,7 @@ pub(crate) async fn create_metric(
             unit_conversion_rounding,
             segmentation_matrix: payload.segmentation_matrix.map(Into::into),
             usage_group_key: payload.usage_group_key,
-            created_by: authorized_state.actor_id,
+            created_by: authorized_state.actor.id(),
             tenant_id: authorized_state.tenant_id,
             product_family_id: payload.product_family_id,
             product_id: payload.product_id,

--- a/modules/meteroid/src/api_rest/plans/router.rs
+++ b/modules/meteroid/src/api_rest/plans/router.rs
@@ -188,7 +188,7 @@ pub(crate) async fn create_plan(
         plan: PlanNew {
             name: payload.name,
             description: payload.description,
-            created_by: authorized_state.actor_id,
+            created_by: authorized_state.actor.id(),
             tenant_id: authorized_state.tenant_id,
             product_family_id: payload.product_family_id,
             plan_type: payload.plan_type.into(),
@@ -352,7 +352,7 @@ pub(crate) async fn replace_plan(
         .replace_plan_version(
             plan_id,
             authorized_state.tenant_id,
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
             payload.name,
             payload.description,
             PlanVersionNewInternal {
@@ -514,7 +514,7 @@ pub(crate) async fn publish_plan(
         .publish_plan_version(
             draft_version.id,
             authorized_state.tenant_id,
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
         )
         .await
         .map_err(|e| {

--- a/modules/meteroid/src/api_rest/productfamilies/router.rs
+++ b/modules/meteroid/src/api_rest/productfamilies/router.rs
@@ -97,7 +97,7 @@ pub(crate) async fn create_product_family(
         .store
         .insert_product_family(
             create_req_to_domain(payload, authorized_state.tenant_id),
-            Some(authorized_state.actor_id),
+            Some(authorized_state.actor.id()),
         )
         .await
         .map(|x| (StatusCode::CREATED, Json(domain_to_rest(x))))

--- a/modules/meteroid/src/api_rest/products/router.rs
+++ b/modules/meteroid/src/api_rest/products/router.rs
@@ -147,7 +147,7 @@ pub(crate) async fn create_product(
         .create_product(ProductNew {
             name: payload.name,
             description: payload.description,
-            created_by: authorized_state.actor_id,
+            created_by: authorized_state.actor.id(),
             tenant_id: authorized_state.tenant_id,
             family_id: payload.product_family_id,
             fee_type,

--- a/modules/meteroid/src/api_rest/subscriptions/router.rs
+++ b/modules/meteroid/src/api_rest/subscriptions/router.rs
@@ -234,7 +234,7 @@ pub(crate) async fn create_subscription(
                 resolved_plan_version,
                 resolved_customer_id,
                 resolved_coupon_ids,
-                authorized_state.actor_id,
+                authorized_state.actor.id(),
                 payload,
             )?,
             authorized_state.tenant_id,
@@ -296,7 +296,7 @@ pub(crate) async fn cancel_subscription(
                 .effective_date
                 .map(CancellationEffectiveAt::Date)
                 .unwrap_or(CancellationEffectiveAt::EndOfBillingPeriod),
-            authorized_state.actor_id,
+            authorized_state.actor.id(),
         )
         .await
         .map_err(|e| {

--- a/modules/meteroid/src/config.rs
+++ b/modules/meteroid/src/config.rs
@@ -85,6 +85,9 @@ pub struct Config {
     #[envconfig(from = "ADMIN_ORGANIZATION_ID")]
     pub admin_organization_id: Option<OrganizationId>,
 
+    #[envconfig(from = "ORGANIZATION_INVITE_TTL_DAYS", default = "7")]
+    pub invite_ttl_days: u32,
+
     #[envconfig(nested)]
     pub redis: RedisConfig,
 }

--- a/modules/meteroid/src/singletons.rs
+++ b/modules/meteroid/src/singletons.rs
@@ -35,6 +35,7 @@ pub async fn get_store() -> &'static Store {
                 billing_default_plan_id: None,
                 admin_organization_id: config.admin_organization_id,
                 usage_client: Arc::new(MeteringUsageClient::get().clone()),
+                invite_ttl_days: config.invite_ttl_days,
             })
             .expect("Failed to initialize store");
 

--- a/modules/meteroid/tests/integration/data/minimal.rs
+++ b/modules/meteroid/tests/integration/data/minimal.rs
@@ -9,7 +9,7 @@ use diesel_models::errors::DatabaseErrorContainer;
 use diesel_models::historical_rates_from_usd::HistoricalRatesFromUsdRowNew;
 use diesel_models::invoicing_entities::InvoicingEntityRow;
 use diesel_models::organization_members::OrganizationMemberRow;
-use diesel_models::organizations::{OrganizationRow, OrganizationRowNew};
+use diesel_models::organizations::OrganizationRowNew;
 use diesel_models::product_families::ProductFamilyRowNew;
 use diesel_models::tenants::TenantRowNew;
 use diesel_models::users::UserRowNew;
@@ -32,12 +32,6 @@ pub async fn run_minimal_seed(pool: &PgPool) {
             default_country: CountryCode::from_str("FR").expect("failed to parse country code"),
             is_express: false,
         }.insert(tx).await?;
-
-        OrganizationRow::update_invite_link(
-            tx,
-            ids::ORGANIZATION_ID,
-            &"fake-invite-link".to_string(),
-        ).await?;
 
         // create user
         UserRowNew {

--- a/modules/meteroid/tests/integration/meteroid_it/config.rs
+++ b/modules/meteroid/tests/integration/meteroid_it/config.rs
@@ -61,6 +61,7 @@ pub fn mocked_config(
         oauth: OauthConfig::dummy(),
         domains_whitelist: None,
         admin_organization_id: None,
+        invite_ttl_days: 7,
         redis: Default::default(),
     }
 }

--- a/modules/meteroid/tests/integration/meteroid_it/container.rs
+++ b/modules/meteroid/tests/integration/meteroid_it/container.rs
@@ -209,6 +209,7 @@ async fn start_meteroid_from_config(
         billing_default_plan_id: None,
         admin_organization_id: None,
         usage_client: usage_client.clone(),
+        invite_ttl_days: 7,
     })
     .expect("Could not create store");
 

--- a/modules/meteroid/tests/integration/test_user.rs
+++ b/modules/meteroid/tests/integration/test_user.rs
@@ -3,16 +3,28 @@ use crate::meteroid_it::svc_auth::SEED_USERNAME;
 use crate::{helpers, meteroid_it};
 use meteroid_grpc::meteroid::api;
 
+async fn invite_and_get_token(clients: &meteroid_it::clients::AllClients, email: &str) -> String {
+    clients
+        .users
+        .clone()
+        .invite_member(api::users::v1::InviteMemberRequest {
+            email: email.to_string(),
+            role: api::users::v1::OrganizationUserRole::Member as i32,
+        })
+        .await
+        .unwrap()
+        .into_inner()
+        .invite_id
+}
+
 #[tokio::test]
 async fn test_users_basic() {
-    // Generic setup
     helpers::init::logging();
     let postgres_connection_string = meteroid_it::container::create_test_database().await;
     let setup =
         meteroid_it::container::start_meteroid(postgres_connection_string, SeedLevel::MINIMAL)
             .await;
 
-    // login
     let auth = meteroid_it::svc_auth::login(setup.channel.clone()).await;
 
     let clients = meteroid_it::clients::AllClients::from_channel(
@@ -33,8 +45,6 @@ async fn test_users_basic() {
         .user
         .unwrap();
 
-    // TODO check if /me should have role
-    // assert_eq!(me.role, UserRole::Admin as i32);
     assert_eq!(me.email, SEED_USERNAME);
 
     // get by id
@@ -61,29 +71,26 @@ async fn test_users_basic() {
         .users;
 
     assert_eq!(users.len(), 1);
+    assert_eq!(users[0].email, me.email);
 
-    let user = users.first().unwrap().clone();
-    assert_eq!(user.email, me.email);
+    // invite + register via invite token
+    let new_email = "meteroid-abcd@def.com";
+    let invite_id = invite_and_get_token(&clients, new_email).await;
 
-    // register
-    let new_email: String = "meteroid-abcd@def.com".into();
-    let new_pass: String = "super-secret".into();
-    let invite_key: String = "fake-invite-link".into();
     let resp = clients
         .users
         .clone()
         .complete_registration(api::users::v1::CompleteRegistrationRequest {
-            email: new_email.clone(),
-            password: new_pass.clone(),
-            invite_key: Some(invite_key),
+            email: new_email.to_string(),
+            password: "super-secret".to_string(),
+            invite_key: Some(invite_id),
             validation_token: None,
         })
         .await
         .unwrap()
         .into_inner();
 
-    let user = resp.user.unwrap();
-    assert_eq!(user.email, new_email.clone());
+    assert_eq!(resp.user.unwrap().email, new_email);
 }
 
 #[tokio::test]
@@ -122,21 +129,22 @@ async fn test_leave_and_remove_member() {
     assert!(leave_err.is_err());
     assert_eq!(leave_err.unwrap_err().code(), tonic::Code::InvalidArgument);
 
-    // Register a second user via the seed invite link
-    let second_email = "second@meteroid.dev".to_string();
+    // Invite + register a second user
+    let second_email = "second@meteroid.dev";
+    let invite_id = invite_and_get_token(&clients, second_email).await;
+
     clients
         .users
         .clone()
         .complete_registration(api::users::v1::CompleteRegistrationRequest {
-            email: second_email.clone(),
+            email: second_email.to_string(),
             password: "super-secret".to_string(),
-            invite_key: Some("fake-invite-link".to_string()),
+            invite_key: Some(invite_id),
             validation_token: None,
         })
         .await
         .unwrap();
 
-    // List users — expect 2
     let users = clients
         .users
         .clone()
@@ -177,7 +185,6 @@ async fn test_leave_and_remove_member() {
         .await
         .unwrap();
 
-    // List users — back to 1
     let users = clients
         .users
         .clone()
@@ -188,4 +195,231 @@ async fn test_leave_and_remove_member() {
         .users;
     assert_eq!(users.len(), 1);
     assert_eq!(users[0].id, me.id);
+}
+
+#[tokio::test]
+async fn test_org_invite_flow() {
+    helpers::init::logging();
+    let postgres_connection_string = meteroid_it::container::create_test_database().await;
+    let setup =
+        meteroid_it::container::start_meteroid(postgres_connection_string, SeedLevel::MINIMAL)
+            .await;
+
+    let auth = meteroid_it::svc_auth::login(setup.channel.clone()).await;
+
+    let admin_clients = meteroid_it::clients::AllClients::from_channel(
+        setup.channel.clone(),
+        auth.token.clone().as_str(),
+        "TESTORG",
+        "testslug",
+    );
+
+    // Anonymous client (no bearer token) for GetInviteDetails
+    let anon_clients =
+        meteroid_it::clients::AllClients::from_channel(setup.channel.clone(), "", "", "");
+
+    let invitee_email = "invitee@example.com";
+
+    let me_email = SEED_USERNAME;
+    let self_invite_err = admin_clients
+        .users
+        .clone()
+        .invite_member(api::users::v1::InviteMemberRequest {
+            email: me_email.to_string(),
+            role: api::users::v1::OrganizationUserRole::Member as i32,
+        })
+        .await;
+    assert!(self_invite_err.is_err());
+    assert_eq!(
+        self_invite_err.unwrap_err().code(),
+        tonic::Code::InvalidArgument
+    );
+
+    admin_clients
+        .users
+        .clone()
+        .invite_member(api::users::v1::InviteMemberRequest {
+            email: invitee_email.to_string(),
+            role: api::users::v1::OrganizationUserRole::Member as i32,
+        })
+        .await
+        .unwrap();
+
+    let dup_err = admin_clients
+        .users
+        .clone()
+        .invite_member(api::users::v1::InviteMemberRequest {
+            email: invitee_email.to_string(),
+            role: api::users::v1::OrganizationUserRole::Member as i32,
+        })
+        .await;
+    assert!(dup_err.is_err());
+    assert_eq!(dup_err.unwrap_err().code(), tonic::Code::InvalidArgument);
+
+    let invites = admin_clients
+        .users
+        .clone()
+        .list_pending_invites(api::users::v1::ListPendingInvitesRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .invites;
+
+    assert_eq!(invites.len(), 1);
+    let invite = invites.into_iter().next().unwrap();
+    assert_eq!(invite.invited_email, invitee_email);
+    assert_eq!(
+        invite.role,
+        api::users::v1::OrganizationUserRole::Member as i32
+    );
+    assert!(!invite.is_expired);
+
+    let invite_id = invite.id.clone();
+
+    let details = anon_clients
+        .instance
+        .clone()
+        .get_invite_details(api::instance::v1::GetInviteDetailsRequest {
+            invite_id: invite_id.clone(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!details.organization_name.is_empty());
+    assert_eq!(
+        details.role,
+        api::users::v1::OrganizationUserRole::Member as i32
+    );
+    assert_eq!(details.invited_email, invitee_email);
+
+    let bad_token_err = anon_clients
+        .instance
+        .clone()
+        .get_invite_details(api::instance::v1::GetInviteDetailsRequest {
+            invite_id: "orginv_notreal".to_string(),
+        })
+        .await;
+    assert!(bad_token_err.is_err());
+
+    admin_clients
+        .users
+        .clone()
+        .resend_invite(api::users::v1::ResendInviteRequest {
+            invite_id: invite_id.clone(),
+        })
+        .await
+        .unwrap();
+
+    let wrong_email_err = admin_clients
+        .users
+        .clone()
+        .complete_registration(api::users::v1::CompleteRegistrationRequest {
+            email: "wrong@example.com".to_string(),
+            password: "pass1234".to_string(),
+            invite_key: Some(invite_id.clone()),
+            validation_token: None,
+        })
+        .await;
+    assert!(wrong_email_err.is_err());
+
+    admin_clients
+        .users
+        .clone()
+        .complete_registration(api::users::v1::CompleteRegistrationRequest {
+            email: invitee_email.to_string(),
+            password: "pass1234".to_string(),
+            invite_key: Some(invite_id.clone()),
+            validation_token: None,
+        })
+        .await
+        .unwrap();
+
+    let used_token_err = anon_clients
+        .instance
+        .clone()
+        .get_invite_details(api::instance::v1::GetInviteDetailsRequest {
+            invite_id: invite_id.clone(),
+        })
+        .await;
+    assert!(used_token_err.is_err());
+
+    let reuse_err = admin_clients
+        .users
+        .clone()
+        .complete_registration(api::users::v1::CompleteRegistrationRequest {
+            email: invitee_email.to_string(),
+            password: "pass1234".to_string(),
+            invite_key: Some(invite_id.clone()),
+            validation_token: None,
+        })
+        .await;
+    assert!(reuse_err.is_err());
+
+    let third_email = "third@example.com";
+    let third_invite_id = invite_and_get_token(&admin_clients, third_email).await;
+
+    admin_clients
+        .users
+        .clone()
+        .complete_registration(api::users::v1::CompleteRegistrationRequest {
+            email: third_email.to_string(),
+            password: "pass1234".to_string(),
+            invite_key: Some(third_invite_id.clone()),
+            validation_token: None,
+        })
+        .await
+        .unwrap();
+
+    let fourth_email = "fourth@example.com";
+    let fourth_invite_id = invite_and_get_token(&admin_clients, fourth_email).await;
+
+    admin_clients
+        .users
+        .clone()
+        .revoke_invite(api::users::v1::RevokeInviteRequest {
+            invite_id: fourth_invite_id.clone(),
+        })
+        .await
+        .unwrap();
+
+    let revoked_err = anon_clients
+        .instance
+        .clone()
+        .get_invite_details(api::instance::v1::GetInviteDetailsRequest {
+            invite_id: fourth_invite_id.clone(),
+        })
+        .await;
+    assert!(revoked_err.is_err());
+
+    let reg_err = admin_clients
+        .users
+        .clone()
+        .complete_registration(api::users::v1::CompleteRegistrationRequest {
+            email: fourth_email.to_string(),
+            password: "pass1234".to_string(),
+            invite_key: Some(fourth_invite_id.clone()),
+            validation_token: None,
+        })
+        .await;
+    assert!(reg_err.is_err());
+
+    let double_revoke_err = admin_clients
+        .users
+        .clone()
+        .revoke_invite(api::users::v1::RevokeInviteRequest {
+            invite_id: fourth_invite_id.clone(),
+        })
+        .await;
+    assert!(double_revoke_err.is_err());
+
+    let users = admin_clients
+        .users
+        .clone()
+        .list_users(api::users::v1::ListUsersRequest {})
+        .await
+        .unwrap()
+        .into_inner()
+        .users;
+    assert_eq!(users.len(), 3);
 }

--- a/modules/web/web-app/features/auth/components/RegistrationForm.tsx
+++ b/modules/web/web-app/features/auth/components/RegistrationForm.tsx
@@ -1,13 +1,17 @@
-import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query'
+import { createConnectQueryKey, disableQuery, useMutation } from '@connectrpc/connect-query'
 import { Button, Form, InputFormField } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
 import { z } from 'zod'
 
 import { useZodForm } from '@/hooks/useZodForm'
+import { useQuery } from '@/lib/connectrpc'
 import { schemas } from '@/lib/schemas'
-import { INVITE_TOKEN_KEY } from '@/pages/invite/acceptInvite'
-import { getInstance } from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
+import {
+  getInviteDetails,
+  getInstance,
+} from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
 import { initRegistration } from '@/rpc/api/users/v1/users-UsersService_connectquery'
 
 export const RETURN_URL_KEY = 'pending_return_url'
@@ -18,6 +22,13 @@ export const RegistrationForm = ({ invite }: { invite?: string }) => {
   const queryClient = useQueryClient()
   const returnUrl = searchParams.get('returnUrl')
 
+  const { data: inviteData } = useQuery(
+    getInviteDetails,
+    invite ? { inviteId: invite } : disableQuery,
+  )
+
+  const lockedEmail = inviteData?.invitedEmail
+
   const methods = useZodForm({
     schema: schemas.me.emailSchema,
     defaultValues: {
@@ -25,6 +36,14 @@ export const RegistrationForm = ({ invite }: { invite?: string }) => {
     },
     mode: 'onSubmit',
   })
+
+  const { setValue } = methods
+
+  useEffect(() => {
+    if (lockedEmail) {
+      setValue('email', lockedEmail, { shouldValidate: true })
+    }
+  }, [lockedEmail, setValue])
 
   const registerMut = useMutation(initRegistration, {
     onSuccess: () => {
@@ -43,13 +62,6 @@ export const RegistrationForm = ({ invite }: { invite?: string }) => {
       inviteKey: invite,
     })
 
-    // Clear invite token from sessionStorage after successful registration init
-    // The invite will be handled during completeRegistration
-    if (invite) {
-      sessionStorage.removeItem(INVITE_TOKEN_KEY)
-    }
-
-    // Store returnUrl for after registration completes
     if (returnUrl && returnUrl.startsWith('/')) {
       sessionStorage.setItem(RETURN_URL_KEY, returnUrl)
     }
@@ -68,12 +80,15 @@ export const RegistrationForm = ({ invite }: { invite?: string }) => {
       <form onSubmit={methods.handleSubmit(onSubmit)}>
         <div className="flex flex-col gap-6">
           <InputFormField
-            autoFocus
+            autoFocus={!lockedEmail}
             name="email"
             label="Work email"
             control={methods.control}
             placeholder="you@company.com"
             id="signup-email"
+            readOnly={!!lockedEmail}
+            className={lockedEmail ? 'opacity-50 cursor-not-allowed' : undefined}
+            description={lockedEmail ? 'This email is set by your invite and cannot be changed.' : undefined}
           />
           <Button variant="primary" type="submit" disabled={!methods.formState.isValid}>
             Continue

--- a/modules/web/web-app/features/auth/components/ValidateEmailForm.tsx
+++ b/modules/web/web-app/features/auth/components/ValidateEmailForm.tsx
@@ -7,6 +7,7 @@ import { useSession } from '@/features/auth/session'
 import { useZodForm } from '@/hooks/useZodForm'
 import { queryClient } from '@/lib/react-query'
 import { schemas } from '@/lib/schemas'
+import { INVITE_TOKEN_KEY } from '@/pages/invite/acceptInvite'
 import { getInstance } from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
 import { completeRegistration } from '@/rpc/api/users/v1/users-UsersService_connectquery'
 
@@ -39,14 +40,17 @@ export const ValidateEmailForm = () => {
   })
 
   const onSubmit = async (data: z.infer<typeof schemas.me.validateEmailSchema>) => {
+    const pendingInviteKey = sessionStorage.getItem(INVITE_TOKEN_KEY) ?? undefined
+
     await registerMut.mutateAsync({
-      //If validation is skipped, we get back the email from the state
       email: state,
       password: data.password,
       validationToken: token ?? '',
+      inviteKey: pendingInviteKey,
     })
 
-    // Get and clear the pending return URL
+    sessionStorage.removeItem(INVITE_TOKEN_KEY)
+
     const pendingReturnUrl = sessionStorage.getItem(RETURN_URL_KEY)
     sessionStorage.removeItem(RETURN_URL_KEY)
 

--- a/modules/web/web-app/features/settings/tabs/UsersTab.tsx
+++ b/modules/web/web-app/features/settings/tabs/UsersTab.tsx
@@ -1,4 +1,4 @@
-import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query'
+import { createConnectQueryKey, disableQuery, useMutation } from '@connectrpc/connect-query'
 import {
   Badge,
   Button,
@@ -7,9 +7,16 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  InputWithIcon,
+  Form,
+  InputFormField,
   Label,
   Modal,
+  Separator,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Skeleton,
   Tooltip,
   TooltipContent,
@@ -17,22 +24,32 @@ import {
 } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { ColumnDef } from '@tanstack/react-table'
-import { CopyIcon, MoreVerticalIcon, UserMinusIcon } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { formatDistanceToNow } from 'date-fns'
+import { CopyIcon, MoreVerticalIcon, RefreshCwIcon, UserMinusIcon, XIcon } from 'lucide-react'
+import { useState } from 'react'
 import { toast } from 'sonner'
+import { z } from 'zod'
 
 import { SimpleTable } from '@/components/table/SimpleTable'
+import { useZodForm } from '@/hooks/useZodForm'
 import { useQuery } from '@/lib/connectrpc'
 import { copyToClipboard } from '@/lib/helpers'
-import { getInvite } from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
 import { OrganizationUserRole, UserWithRole } from '@/rpc/api/users/v1/models_pb'
 import {
+  inviteMember,
   leaveOrganization,
+  listPendingInvites,
   listUsers,
   me,
   removeMember,
+  resendInvite,
+  revokeInvite,
 } from '@/rpc/api/users/v1/users-UsersService_connectquery'
+import { OrganizationInvite } from '@/rpc/api/users/v1/users_pb'
+
+const inviteSchema = z.object({
+  email: z.string().email('Please enter a valid email address'),
+})
 
 const userRoleMapping: Record<OrganizationUserRole, string> = {
   [OrganizationUserRole.ADMIN]: 'Owner',
@@ -41,97 +58,158 @@ const userRoleMapping: Record<OrganizationUserRole, string> = {
 
 export const UsersTab = () => {
   const [inviteVisible, setInviteVisible] = useState(false)
+  const [inviteRole, setInviteRole] = useState<OrganizationUserRole>(OrganizationUserRole.MEMBER)
+  const inviteForm = useZodForm({ schema: inviteSchema })
   const [leaveVisible, setLeaveVisible] = useState(false)
   const [memberToRemove, setMemberToRemove] = useState<UserWithRole | null>(null)
+  const [inviteToRevoke, setInviteToRevoke] = useState<OrganizationInvite | null>(null)
   const queryClient = useQueryClient()
-  const navigate = useNavigate()
 
   const meData = useQuery(me).data
   const currentUserId = meData?.user?.id
+  const { data: usersQueryData, refetch: refetchUsers, isFetching: isFetchingUsers } = useQuery(listUsers)
+  const usersData = usersQueryData?.users
+  const isAdmin = usersData?.find(u => u.id === currentUserId)?.role === OrganizationUserRole.ADMIN
+  const { data: pendingInvitesQueryData, refetch: refetchInvites, isFetching: isFetchingInvites } = useQuery(listPendingInvites, isAdmin ? undefined : disableQuery)
+  const pendingInvitesData = pendingInvitesQueryData?.invites
+  const isRefreshing = isFetchingUsers || isFetchingInvites
+  const handleRefresh = () => { refetchUsers(); if (isAdmin) refetchInvites() }
+  const adminCount = usersData?.filter(u => u.role === OrganizationUserRole.ADMIN).length ?? 0
+  const disableLeaveOrg = isAdmin && adminCount <= 1
 
-  const usersData = useQuery(listUsers).data?.users
+  const inviteMemberMut = useMutation(inviteMember, {
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listPendingInvites) })
+      void queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listUsers) })
+      setInviteVisible(false)
+      inviteForm.reset()
+      setInviteRole(OrganizationUserRole.MEMBER)
+      toast.success('Invite sent')
+    },
+    onError: (err: Error) => {
+      toast.error(err.message ?? 'Failed to send invite')
+    },
+  })
 
-  const { isAdmin, disableLeaveOrg } = useMemo(() => {
-    if (!usersData) return { isAdmin: false, disableLeaveOrg: true }
-    const currentUser = usersData.find(u => u.id === currentUserId)
-    const isAdminRole = currentUser?.role === OrganizationUserRole.ADMIN
-    const adminCount = usersData.filter(u => u.role === OrganizationUserRole.ADMIN).length
-    return { isAdmin: isAdminRole, disableLeaveOrg: isAdminRole && adminCount <= 1 }
-  }, [usersData, currentUserId])
+  const resendInviteMut = useMutation(resendInvite, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listPendingInvites) })
+      toast.success('Invite resent')
+    },
+    onError: () => toast.error('Failed to resend invite'),
+  })
+
+  const revokeInviteMut = useMutation(revokeInvite, {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listPendingInvites) })
+      setInviteToRevoke(null)
+      toast.success('Invite revoked')
+    },
+    onError: () => toast.error('Failed to revoke invite'),
+  })
 
   const removeMemberMut = useMutation(removeMember, {
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listUsers) })
       toast.success('Member removed')
     },
-    onError: () => {
-      toast.error('Failed to remove member')
-    },
+    onError: () => toast.error('Failed to remove member'),
   })
 
   const leaveOrganizationMut = useMutation(leaveOrganization, {
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: createConnectQueryKey(listUsers) })
-      navigate('/')
+    onSuccess: () => {
+      window.location.replace('/')
     },
     onError: (err: Error) => {
       toast.error(err.message ?? 'Failed to leave organization')
     },
   })
 
-  const invite = useQuery(getInvite)
-
-  const inviteLink = useMemo(() => {
-    if (!invite?.data?.inviteHash) return undefined
-    return `${window.location.origin}/invite?token=${invite.data.inviteHash}`
-  }, [invite?.data?.inviteHash])
-
-  const columns: ColumnDef<UserWithRole>[] = [
+  const memberColumns: ColumnDef<UserWithRole>[] = [
     {
       header: 'Email',
       cell: ({ row }) => (
         <div className="flex items-center gap-2">
           {row.original.email}
           {row.original.id === currentUserId && (
-            <Badge variant="outline" size="sm">
-              You
-            </Badge>
+            <Badge variant="outline" size="sm">You</Badge>
           )}
         </div>
       ),
     },
     { header: 'Role', accessorFn: user => userRoleMapping[user.role] },
     ...(isAdmin
-      ? [
-        {
-          id: 'actions',
-          cell: ({ row }: { row: { original: UserWithRole } }) => {
-            if (row.original.id === currentUserId) return null
-            return (
-              <div className="flex justify-end">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="ghost" size="sm">
-                      <MoreVerticalIcon size={16} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onClick={() => setMemberToRemove(row.original)}>
-                      <UserMinusIcon size={16} className="mr-2" />
-                      Remove
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            )
-          },
-        } satisfies ColumnDef<UserWithRole>,
-      ]
+      ? [{
+        id: 'actions',
+        cell: ({ row }: { row: { original: UserWithRole } }) => {
+          if (row.original.id === currentUserId) return null
+          return (
+            <div className="flex justify-end">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="sm"><MoreVerticalIcon size={16}/></Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onClick={() => setMemberToRemove(row.original)}>
+                    <UserMinusIcon size={16} className="mr-2"/>Remove
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          )
+        },
+      } satisfies ColumnDef<UserWithRole>]
+      : []),
+  ]
+
+  const inviteColumns: ColumnDef<OrganizationInvite>[] = [
+    { header: 'Email', accessorKey: 'invitedEmail' },
+    { header: 'Role', accessorFn: inv => userRoleMapping[inv.role] },
+    { header: 'Invited by', accessorKey: 'invitedByEmail' },
+    {
+      header: 'Expires',
+      cell: ({ row }) => {
+        const date = new Date(row.original.expiresAt)
+        const label = formatDistanceToNow(date, { addSuffix: true })
+        return row.original.isExpired
+          ? <Badge variant="destructive" size="sm">Expired {label}</Badge>
+          : <span className="text-sm text-muted-foreground">{label}</span>
+      },
+    },
+    ...(isAdmin
+      ? [{
+        id: 'actions',
+        cell: ({ row }: { row: { original: OrganizationInvite } }) => (
+          <div className="flex justify-end">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm"><MoreVerticalIcon size={16}/></Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => copyToClipboard(
+                  `${window.location.origin}/invite?token=${row.original.id}`,
+                  () => toast.success('Invite link copied')
+                )}>
+                  <CopyIcon size={16} className="mr-2"/>Copy invite link
+                </DropdownMenuItem>
+                {!row.original.isExpired && (
+                  <DropdownMenuItem onClick={() => resendInviteMut.mutate({ inviteId: row.original.id })}>
+                    <RefreshCwIcon size={16} className="mr-2"/>Resend invite
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem onClick={() => setInviteToRevoke(row.original)}>
+                  <XIcon size={16} className="mr-2"/>Revoke invite
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        ),
+      } satisfies ColumnDef<OrganizationInvite>]
       : []),
   ]
 
   return (
-    <Card className="px-8 py-6 space-y-2">
+    <Card className="px-8 py-6 space-y-6">
       <div className="flex justify-end items-center gap-2">
         <Tooltip>
           <TooltipTrigger asChild>
@@ -142,63 +220,123 @@ export const UsersTab = () => {
             </span>
           </TooltipTrigger>
           {disableLeaveOrg && (
-            <TooltipContent>
-              You cannot leave the organization as you are the only admin.
-            </TooltipContent>
+            <TooltipContent>You cannot leave as the only admin.</TooltipContent>
           )}
         </Tooltip>
-
-        <Button variant="secondary" onClick={() => setInviteVisible(true)}>
-          Invite users
-        </Button>
+        {isAdmin && (
+          <Button variant="secondary" onClick={() => setInviteVisible(true)}>
+            Invite member
+          </Button>
+        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="outline" size="sm" disabled={isRefreshing} onClick={handleRefresh}>
+              <RefreshCwIcon size={14} className={isRefreshing ? 'animate-spin' : ''} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>Refresh</TooltipContent>
+        </Tooltip>
       </div>
 
-      <div className="max-h-screen overflow-y-auto">
-        <SimpleTable columns={columns} data={usersData ?? []}/>
+      <div className="space-y-2">
+        <Label className="text-sm font-medium">Members</Label>
+        <SimpleTable columns={memberColumns} data={usersData ?? []}/>
       </div>
 
+      {isAdmin && (
+        <>
+          <Separator/>
+          <div className="space-y-2">
+            <Label className="text-sm font-medium">Pending invites</Label>
+            {pendingInvitesData === undefined ? (
+              <Skeleton height="4rem" width="100%"/>
+            ) : pendingInvitesData.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No pending invites.</p>
+            ) : (
+              <SimpleTable columns={inviteColumns} data={pendingInvitesData}/>
+            )}
+          </div>
+        </>
+      )}
+
+      {/* Invite modal */}
       <Modal
         visible={inviteVisible}
-        onCancel={() => setInviteVisible(false)}
-        hideFooter
-        header={<>Invite users</>}
+        onCancel={() => {
+          setInviteVisible(false)
+          inviteForm.reset()
+          setInviteRole(OrganizationUserRole.MEMBER)
+        }}
+        header={<>Invite member</>}
+        onConfirm={() =>
+          inviteForm.handleSubmit(({ email }) =>
+            inviteMemberMut.mutate({ email, role: inviteRole })
+          )()
+        }
+        confirmText="Send invite"
       >
-        <div className="p-6 space-y-2">
-          <Label className="mb-2 text-muted-foreground">
-            Send this invite link to your colleagues
-          </Label>
-          {inviteLink ? (
-            <InputWithIcon
-              value={inviteLink}
-              readOnly
-              icon={<CopyIcon className="group-hover:text-brand"/>}
-              className="cursor-pointer"
-              containerClassName="group"
-              onClick={() => copyToClipboard(inviteLink, () => toast.success('Copied !'))}
+        <Form {...inviteForm}>
+          <div className="p-6 space-y-4">
+            <InputFormField
+              control={inviteForm.control}
+              name="email"
+              label="Email address"
+              placeholder="colleague@company.com"
+              type="email"
             />
-          ) : (
-            <Skeleton height="2rem" width="100%"/>
-          )}
+            <div className="space-y-1">
+              <Label>Role</Label>
+              <Select
+                value={String(inviteRole)}
+                onValueChange={v => setInviteRole(Number(v) as OrganizationUserRole)}
+              >
+                <SelectTrigger><SelectValue/></SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={String(OrganizationUserRole.MEMBER)}>Member</SelectItem>
+                  <SelectItem value={String(OrganizationUserRole.ADMIN)}>Owner</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </Form>
+      </Modal>
+
+      {/* Revoke invite modal */}
+      <Modal
+        visible={!!inviteToRevoke}
+        onCancel={() => setInviteToRevoke(null)}
+        header={<>Revoke invite</>}
+        onConfirm={() => {
+          if (!inviteToRevoke) return
+          revokeInviteMut.mutate({ inviteId: inviteToRevoke.id })
+        }}
+        confirmText="Revoke"
+      >
+        <div className="p-6">
+          <p className="text-sm">
+            Revoke the invite sent to <strong>{inviteToRevoke?.invitedEmail}</strong>? They will no longer be able to
+            use this link.
+          </p>
         </div>
       </Modal>
 
+      {/* Leave org modal */}
       <Modal
         visible={leaveVisible}
         onCancel={() => setLeaveVisible(false)}
         header={<>Leave organization</>}
         onConfirm={() => {
-          setLeaveVisible(false)
+          setLeaveVisible(false);
           leaveOrganizationMut.mutate({})
         }}
         confirmText="Leave"
       >
         <div className="p-6">
-          <p className="text-sm">
-            Are you sure you want to leave this organization? You will lose access immediately.
-          </p>
+          <p className="text-sm">Are you sure you want to leave this organization? You will lose access immediately.</p>
         </div>
       </Modal>
 
+      {/* Remove member modal */}
       <Modal
         visible={!!memberToRemove}
         onCancel={() => setMemberToRemove(null)}
@@ -212,8 +350,7 @@ export const UsersTab = () => {
       >
         <div className="p-6">
           <p className="text-sm">
-            Are you sure you want to remove <strong>{memberToRemove?.email}</strong> from this
-            organization?
+            Remove <strong>{memberToRemove?.email}</strong> from this organization?
           </p>
         </div>
       </Modal>

--- a/modules/web/web-app/pages/invite/acceptInvite.tsx
+++ b/modules/web/web-app/pages/invite/acceptInvite.tsx
@@ -6,7 +6,8 @@ import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import { Loader } from '@/features/auth/components/Loader'
 import { useSession } from '@/features/auth/session'
 import { useQuery } from '@/lib/connectrpc'
-import { getOrganizationByInviteLink } from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
+import { getInviteDetails } from '@/rpc/api/instance/v1/instance-InstanceService_connectquery'
+import { OrganizationUserRole } from '@/rpc/api/users/v1/models_pb'
 
 export const INVITE_TOKEN_KEY = 'pending_invite_token'
 
@@ -17,50 +18,59 @@ export const AcceptInvite = () => {
   const [showChoice, setShowChoice] = useState(false)
   const [inviteToken, setInviteToken] = useState<string | null>(null)
 
-  const { data: orgData, isLoading: isLoadingOrg } = useQuery(
-    getOrganizationByInviteLink,
-    inviteToken ? { inviteKey: inviteToken } : disableQuery,
-    { enabled: !!inviteToken }
+  const { data: inviteData, isLoading, isError } = useQuery(
+    getInviteDetails,
+    inviteToken ? { inviteId: inviteToken } : disableQuery,
   )
 
   useEffect(() => {
     const token = searchParams.get('token') || searchParams.get('invite')
 
     if (!token) {
-      // No invite token, redirect to home
       navigate('/')
       return
     }
 
-    // Store the invite token in sessionStorage for later use (scoped to this tab)
     sessionStorage.setItem(INVITE_TOKEN_KEY, token)
     setInviteToken(token)
 
-    // If user is already authenticated, accept the invite immediately
     if (session) {
       navigate('/invite-authenticated')
       return
     }
 
-    // User is not authenticated - show choice between login and registration
     setShowChoice(true)
   }, [searchParams, session, navigate])
 
-  if (!showChoice || isLoadingOrg) {
+  if (!showChoice || isLoading) {
     return <Loader />
   }
+
+  if (isError || !inviteData) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-screen p-8">
+        <div className="max-w-md w-full space-y-4 text-center">
+          <h1 className="text-2xl font-semibold">Invalid or expired invite link</h1>
+          <p className="text-muted-foreground">
+            This invite link is no longer valid. Please contact the organization admin for a new
+            invite.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  const roleName = inviteData.role === OrganizationUserRole.ADMIN ? 'Owner' : 'Member'
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-8">
       <div className="max-w-md w-full space-y-6">
         <div className="text-center">
           <h1 className="text-2xl font-semibold mb-2">
-            {orgData?.organizationName
-              ? `You've been invited to join ${orgData.organizationName}!`
-              : "You've been invited!"}
+            You&apos;ve been invited to join {inviteData.organizationName}!
           </h1>
           <p className="text-muted-foreground mb-6">
-            To accept this invite, please sign in or create a new account.
+            You&apos;ll join as <strong>{roleName}</strong>. Sign in or create an account to accept.
           </p>
         </div>
 
@@ -70,7 +80,6 @@ export const AcceptInvite = () => {
               Sign in to existing account
             </Button>
           </Link>
-
           <Link to="/registration" className="block">
             <Button variant="secondary" className="w-full">
               Create new account

--- a/modules/web/web-app/pages/invite/inviteAuthenticated.tsx
+++ b/modules/web/web-app/pages/invite/inviteAuthenticated.tsx
@@ -51,7 +51,7 @@ export const InviteAuthenticated = () => {
       return
     }
 
-    acceptInviteMut.mutate({ inviteKey: inviteToken })
+    acceptInviteMut.mutate({ inviteId: inviteToken })
   }, [])
 
   return <Loader />


### PR DESCRIPTION
## Description
Organization invite flow
  
  Replaces the previous link-based invite system with a proper email-based invite flow.

  What's new:
  - Admins can invite team members by email, with a role (Member or Owner)
  - Invitees receive an email with a join link
  - Pending invites are visible in Settings → Users, with options to resend, revoke, or copy the invite link
  - Invites expire automatically; expired ones are cleaned up before reuse
  - Duplicate invites for the same email are prevented
  - Members no longer see invite management UI (admin-only)
  - Users can leave an organization from Settings → Users

## Checklist
- [ ] The code follows the project's coding conventions and style [guidelines](https://doc.rust-lang.org/1.0.0/style/README.html).
- [ ] All tests related to the changes have passed successfully.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [ ] All new and existing unit tests have passed.
- [ ] I have self-reviewed my code and ensured its quality.
- [ ] I have added/updated necessary comments to aid understanding.
