### PR TITLE
fix(web): repair cache updates after ConnectRPC v2 upgrade

### DIFF
--- a/modules/web/web-app/App.tsx
+++ b/modules/web/web-app/App.tsx
@@ -15,12 +15,15 @@ import { useTheme } from 'providers/ThemeProvider'
 
 import router from './router/router'
 
-export const App: React.FC = () => {
-  const transport = createGrpcWebTransport({
-    baseUrl: env.meteroidApiUri,
-    interceptors: [errorInterceptor, loggingInterceptor, authInterceptor],
-  })
+// A single, stable transport for the app's lifetime. It must not be recreated
+// on render: connect-query derives the query-key's transport id from the
+// transport reference, so a new instance would orphan the entire query cache.
+const transport = createGrpcWebTransport({
+  baseUrl: env.meteroidApiUri,
+  interceptors: [errorInterceptor, loggingInterceptor, authInterceptor],
+})
 
+export const App: React.FC = () => {
   const theme = useTheme()
 
   return (

--- a/modules/web/web-app/features/checkout/components/BillingInfo.tsx
+++ b/modules/web/web-app/features/checkout/components/BillingInfo.tsx
@@ -1,9 +1,5 @@
 import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import { Button, Form, InputFormField, Label } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { Edit2, PlusIcon, XIcon } from 'lucide-react'
@@ -42,17 +38,12 @@ export const BillingInfo = ({ customer, isEditing, setIsEditing }: BillingInfoPr
   const updateBillingInfoMut = useMutation(updateCustomer, {
     onSuccess: res => {
       if (res.customer) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: getCustomerPortalOverview,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(getCustomerPortalOverview, prev => (create(getCustomerPortalOverview.output, ({
-            overview: prev?.overview
-              ? { ...prev.overview, customer: res.customer }
-              : { customer: res.customer },
-          }))))
-        )
+            cardinality: undefined
+          })
+        })
       }
 
       toast.success('Billing information updated successfully')

--- a/modules/web/web-app/features/customers/components/BillingInfo.tsx
+++ b/modules/web/web-app/features/customers/components/BillingInfo.tsx
@@ -1,9 +1,5 @@
 import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -28,19 +24,12 @@ export const BillingInfo = ({ customer, isEditing, setIsEditing }: BillingInfoPr
   const updateBillingInfoMut = useMutation(updateCustomer, {
     onSuccess: res => {
       if (res.customer) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: getCheckout,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(getCheckout, prev => (create(getCheckout.output, ({
-            checkout: prev?.checkout
-              ? { ...prev.checkout, customer: res.customer }
-              : { customer: res.customer },
-
-            checkoutType: prev?.checkoutType
-          }))))
-        )
+            cardinality: undefined
+          })
+        })
       }
 
       toast.success('Billing information updated successfully')

--- a/modules/web/web-app/features/onboarding/userOnboardingForm.tsx
+++ b/modules/web/web-app/features/onboarding/userOnboardingForm.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import { Button, Flex, Form, InputFormField, SelectFormField, SelectItem } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { z } from 'zod'
@@ -24,15 +19,12 @@ export const UserOnboardingForm = () => {
   const onboardMeMut = useMutation(onboardMe, {
     onSuccess: async res => {
       if (res.user) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: me,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(me, prev => {
-            return create(me.output, prev ? { ...prev, user: res.user } : { user: res.user });
+            cardinality: undefined
           })
-        )
+        })
       }
     },
   })

--- a/modules/web/web-app/features/plans/pricecomponents/AddComponentPanel.tsx
+++ b/modules/web/web-app/features/plans/pricecomponents/AddComponentPanel.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import {
   ScrollArea,
   Sheet,
@@ -62,16 +57,12 @@ export const AddComponentPanel = () => {
     onSuccess: data => {
       if (!version?.id) return
       if (data.component) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listPriceComponents,
-            input: { planVersionId: version.id },
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listPriceComponents, prev => (create(listPriceComponents.output, ({
-            components: [...(prev?.components ?? []), data.component!]
-          }))))
-        )
+            cardinality: undefined
+          })
+        })
       }
       queryClient.invalidateQueries({ queryKey: createConnectQueryKey({
         schema: getResolvedEntitlementsForPlanVersion.parent,

--- a/modules/web/web-app/features/plans/pricecomponents/EditPriceComponent.tsx
+++ b/modules/web/web-app/features/plans/pricecomponents/EditPriceComponent.tsx
@@ -1,10 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  skipToken,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, skipToken, useMutation } from '@connectrpc/connect-query';
 import { Form } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { useSetAtom } from 'jotai'
@@ -120,24 +114,12 @@ export const EditPriceComponent = ({ component }: EditPriceComponentProps) => {
       setEditedComponents(components => components.filter(compId => compId !== component.id))
 
       if (data.component) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listPriceComponentsQuery,
-
-            input: {
-              planVersionId: version.id,
-            },
-
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listPriceComponentsQuery, prev => {
-            const idx = prev?.components?.findIndex(comp => comp.id === component.id) ?? -1
-            if (idx === -1 || !data.component) return prev
-            const updated = [...(prev?.components ?? [])]
-            updated[idx] = data.component
-            return create(listPriceComponentsQuery.output, { components: updated });
+            cardinality: undefined
           })
-        )
+        })
       }
       queryClient.invalidateQueries({ queryKey: createConnectQueryKey({
         schema: getResolvedEntitlementsForPlanVersion.parent,

--- a/modules/web/web-app/features/plans/pricecomponents/PriceComponentCard.tsx
+++ b/modules/web/web-app/features/plans/pricecomponents/PriceComponentCard.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import { Button } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { useAtom } from 'jotai'
@@ -49,20 +44,12 @@ export const PriceComponentCard: React.FC<{
   const deleteComponentMutation = useMutation(removePriceComponent, {
     onSuccess: () => {
       planWithVersion.version &&
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listPriceComponents,
-
-            input: {
-              planVersionId: planWithVersion.version.id,
-            },
-
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listPriceComponents, prev => (create(listPriceComponents.output, ({
-            components: prev?.components.filter(c => c.id !== component.id) ?? []
-          }))))
-        )
+            cardinality: undefined
+          })
+        })
       queryClient.invalidateQueries({ queryKey: createConnectQueryKey({
         schema: getResolvedEntitlementsForPlanVersion.parent,
         cardinality: undefined

--- a/modules/web/web-app/features/settings/CreateInvoiceEntityDialog.tsx
+++ b/modules/web/web-app/features/settings/CreateInvoiceEntityDialog.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import {
   Button,
   Dialog,
@@ -45,17 +40,12 @@ export const CreateInvoicingEntityDialog = ({
   const createInvoicingEntityMut = useMutation(createInvoicingEntity, {
     onSuccess: async res => {
       if (res.entity) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listInvoicingEntities,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listInvoicingEntities, prev => {
-            return create(listInvoicingEntities.output, {
-              entities: [...(prev?.entities ?? []), res.entity!],
-            });
+            cardinality: undefined
           })
-        )
+        })
         toast.success('Invoicing entity created')
         setInvoicingEntity(res.entity.id)
         setOpen(false)

--- a/modules/web/web-app/features/settings/tabs/CompanyTab.tsx
+++ b/modules/web/web-app/features/settings/tabs/CompanyTab.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import {
   Button,
   Card,
@@ -64,23 +59,12 @@ export const CompanyTab = () => {
   const updateInvoicingEntityMut = useMutation(updateInvoicingEntity, {
     onSuccess: async res => {
       if (res.entity) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listInvoicingEntities,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listInvoicingEntities, prev => {
-            return create(listInvoicingEntities.output, {
-              entities: prev?.entities.map(entity => {
-                if (entity.id === res.entity?.id) {
-                  return res.entity
-                } else {
-                  return entity
-                }
-              }),
-            });
+            cardinality: undefined
           })
-        )
+        })
         queryClient.invalidateQueries({
           queryKey: createConnectQueryKey({
             schema: getInvoicingEntity,
@@ -272,21 +256,13 @@ const FileUpload = ({ entity }: { entity: InvoicingEntity }) => {
   const queryClient = useQueryClient()
 
   const updateInvoicingEntityMut = useMutation(uploadInvoicingEntityLogo, {
-    onSuccess: async res => {
-      queryClient.setQueryData(
-        createConnectQueryKey({
+    onSuccess: async () => {
+      queryClient.invalidateQueries({
+        queryKey: createConnectQueryKey({
           schema: getInvoicingEntity,
-          input: { id: entity.id },
-          cardinality: 'finite'
-        }),
-        createProtobufSafeUpdater(getInvoicingEntity, prev => {
-          return create(getInvoicingEntity.output, {
-            entity: prev?.entity
-              ? { ...prev.entity, logoAttachmentId: res.logoUid }
-              : { logoAttachmentId: res.logoUid },
-          });
+          cardinality: undefined
         })
-      )
+      })
       toast.success('Invoicing entity updated')
     },
   })

--- a/modules/web/web-app/features/settings/tabs/InvoiceTab.tsx
+++ b/modules/web/web-app/features/settings/tabs/InvoiceTab.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import { Badge, Button, Card, Form, InputFormField, Switch, TextareaFormField } from '@md/ui'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect } from 'react'
@@ -36,23 +31,12 @@ export const InvoiceTab = () => {
   const updateInvoicingEntityMut = useMutation(updateInvoicingEntity, {
     onSuccess: async res => {
       if (res.entity) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listInvoicingEntities,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listInvoicingEntities, prev => {
-            return create(listInvoicingEntities.output, {
-              entities: prev?.entities.map(entity => {
-                if (entity.id === res.entity?.id) {
-                  return res.entity
-                } else {
-                  return entity
-                }
-              }),
-            });
+            cardinality: undefined
           })
-        )
+        })
         toast.success('Invoicing entity updated')
       }
     },

--- a/modules/web/web-app/features/settings/tabs/PaymentsTab.tsx
+++ b/modules/web/web-app/features/settings/tabs/PaymentsTab.tsx
@@ -1,9 +1,4 @@
-import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import {
   Button,
   Card,
@@ -57,21 +52,13 @@ const PaymentMethodsForm = ({
   const queryClient = useQueryClient()
 
   const updateInvoicingEntityMut = useMutation(updateInvoicingEntityProviders, {
-    onSuccess: async res => {
-      queryClient.setQueryData(
-        createConnectQueryKey({
+    onSuccess: async () => {
+      queryClient.invalidateQueries({
+        queryKey: createConnectQueryKey({
           schema: getInvoicingEntityProviders,
-          input: { id: invoiceEntityId },
-          cardinality: 'finite'
-        }),
-        createProtobufSafeUpdater(getInvoicingEntityProviders, () => {
-          return create(getInvoicingEntityProviders.output, {
-            cardProvider: res.cardProvider,
-            directDebitProvider: res.directDebitProvider,
-            bankAccount: res.bankAccount,
-          });
+          cardinality: undefined
         })
-      )
+      })
       toast.success('Payment methods updated')
     },
   })

--- a/modules/web/web-app/features/settings/tabs/TaxesTab.tsx
+++ b/modules/web/web-app/features/settings/tabs/TaxesTab.tsx
@@ -1,9 +1,5 @@
 import { create } from '@bufbuild/protobuf';
-import {
-  createConnectQueryKey,
-  createProtobufSafeUpdater,
-  useMutation,
-} from '@connectrpc/connect-query'
+import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query';
 import {
   Button,
   Card,
@@ -125,23 +121,12 @@ export const TaxesTab = () => {
   const updateInvoicingEntityMut = useMutation(updateInvoicingEntity, {
     onSuccess: async res => {
       if (res.entity) {
-        queryClient.setQueryData(
-          createConnectQueryKey({
+        queryClient.invalidateQueries({
+          queryKey: createConnectQueryKey({
             schema: listInvoicingEntities,
-            cardinality: 'finite'
-          }),
-          createProtobufSafeUpdater(listInvoicingEntities, prev => {
-            return create(listInvoicingEntities.output, {
-              entities: prev?.entities.map(entity => {
-                if (entity.id === res.entity?.id) {
-                  return res.entity
-                } else {
-                  return entity
-                }
-              }),
-            });
+            cardinality: undefined
           })
-        )
+        })
         toast.success('Tax settings updated')
       }
     },

--- a/modules/web/web-app/pages/tenants/invoice/Invoice.tsx
+++ b/modules/web/web-app/pages/tenants/invoice/Invoice.tsx
@@ -1,4 +1,3 @@
-import { create } from '@bufbuild/protobuf'
 import { createConnectQueryKey, useMutation } from '@connectrpc/connect-query'
 import {
   Button,
@@ -208,15 +207,13 @@ export const InvoiceView: React.FC<Props & { invoiceId: string }> = ({ invoice, 
   const [isMarkAsPaidDialogOpen, setIsMarkAsPaidDialogOpen] = useState(false)
 
   const refresh = useMutation(refreshInvoiceData, {
-    onSuccess: async res => {
-      await queryClient.setQueryData(
-        createConnectQueryKey({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: createConnectQueryKey({
           schema: getInvoice,
-          input: { id: invoice?.id ?? '' },
-          cardinality: 'finite'
-        }),
-        create(getInvoice.output, { invoice: res.invoice })
-      )
+          cardinality: undefined
+        })
+      })
     },
   })
 


### PR DESCRIPTION
## Problem

After the ConnectRPC v2 upgrade (#1169), several mutations stopped reflecting in the UI even though the request succeeded — e.g. **add / delete a price component** did nothing visible. Operations that relied on `invalidateQueries` (add add-on, edit customer, add manual payment, update plan/metric name…) kept working.

## Root cause

connect-query v2 query keys are structured and include a **transport id** derived from the transport *reference*:

```
["connect-query", { transport, serviceName, methodName, input, cardinality }]
```

The keys built inside mutation handlers via `createConnectQueryKey({ schema, input, cardinality })` **omitted `transport`**. `setQueryData` requires an *exact* key match, so it wrote to a key no observer was watching → the UI never updated. `invalidateQueries` kept working because it matches keys *partially*.

## Fix

- Replace the optimistic `setQueryData` + `createProtobufSafeUpdater` blocks (the latter is **deprecated** in v2) with plain `invalidateQueries` on a method-level key. Partial matching makes the transport/input irrelevant, the query refetches, and the UI updates — consistent with the rest of the codebase. Far less boilerplate than threading `useTransport()` into every key.
- Hoist the grpc-web transport in `App.tsx` to a module-level singleton so its query-key id stays stable across renders. Recreating it per render would change the transport id and orphan the entire query cache.

## Affected handlers

Price components (add/edit/delete), invoicing-entity tabs (Company/Invoice/Taxes/Payments + create), portal billing info (checkout & customer), user onboarding, and invoice refresh.

## Verification

`tsc --noEmit`, eslint, and the production build all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_0198q7KVQmxndhUiuADuonm7)_