### PR TITLE
fix(k8s): serve REST API at root on its own host in oss sample

### DIFF
--- a/k8s/meteroid/values.yaml
+++ b/k8s/meteroid/values.yaml
@@ -43,8 +43,8 @@ serviceAccount:
 
 global:
   publicAppUrl: "http://meteroid.local"
-  publicApiUrl: "http://api.meteroid.local"
-  publicRestApiUrl: "http://api.meteroid.local/api"
+  publicApiUrl: "http://rpc.meteroid.local"
+  publicRestApiUrl: "http://api.meteroid.local"
 
   telemetry:
     tracingEnabled: false
@@ -122,13 +122,15 @@ ingress:
           pathType: Prefix
           service: web
           port: 80
-    - host: api.meteroid.local
+    - host: rpc.meteroid.local
       paths:
         - path: /
           pathType: Prefix
           service: api
           port: 50061
-        - path: /api
+    - host: api.meteroid.local
+      paths:
+        - path: /
           pathType: Prefix
           service: api
           port: 8080


### PR DESCRIPTION
Give the gRPC API its own host (rpc.meteroid.local) and serve the REST API at root on api.meteroid.local, with publicRestApiUrl dropping the /api suffix. Callback/return routes (/v1/portal/*/return, /webhooks, /files, /oauth) are now reachable and stay outside the /api/ auth-guarded namespace.
 